### PR TITLE
ci: add multi-arch Docker build and push to GHCR

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,60 @@
+name: Build and Push to GHCR
+
+on:
+  push:
+    branches:
+      - master
+    tags:
+      - 'v*'
+  workflow_dispatch:
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=raw,value=latest,enable={{is_default_branch}}
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=sha,prefix=sha-
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/deploy.yml` — the only file changed
- Builds `linux/amd64` + `linux/arm64` via QEMU + Buildx on every push to `master`, on `v*` tags, and on manual dispatch
- Publishes to `ghcr.io/vhrita/musa-bot` with `latest` (default branch), semver (`{{version}}`, `{{major}}.{{minor}}`), and `sha-` tags
- GHA layer cache (`type=gha,mode=max`) for faster rebuilds
- No build-args; no Dockerfile changes

## Test plan

- [ ] Merge PR and verify the Actions run triggers automatically on `master`
- [ ] Confirm `ghcr.io/vhrita/musa-bot:latest` and `ghcr.io/vhrita/musa-bot:sha-<sha>` appear in GitHub Packages
- [ ] Pull the `arm64` image on the Oracle Ampere VM and confirm it runs: `docker run --rm ghcr.io/vhrita/musa-bot:latest node -e "console.log('ok')"`
- [ ] Test tag-triggered build: push a `v1.0.0` tag and verify `1.0.0` + `1.0` tags appear in GHCR

---
Built by VHXCO Agentic Software House