### PR TITLE
fix(docker): copy compiled node_modules from builder — resolve @discordjs/opus musl/Node 22 build failure

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,9 @@
 # ── builder stage ──────────────────────────────────────────────────────────────
-FROM node:22-alpine AS builder
+# ⚠️  Pin Alpine 3.20 (musl 1.2.5) de propósito: @discordjs/opus@0.10.0 só tem
+# prebuild musl-1.2.5 pra Node 22 (node-v127). Alpine 3.21+ usa musl 1.2.6 →
+# prebuild 404 → compila libopus do source → quebra em arm64 (bug ARM NEON
+# celt_inner_prod_neon). NÃO bumpe a versão do Alpine sem reverificar o prebuild.
+FROM node:22-alpine3.20 AS builder
 
 # Build deps for native modules (e.g. @discordjs/opus)
 RUN apk add --no-cache \
@@ -22,7 +26,8 @@ RUN npm run build
 RUN npm prune --omit=dev
 
 # ── production stage ────────────────────────────────────────────────────────────
-FROM node:22-alpine AS production
+# ⚠️  Mesma pin do builder: Alpine 3.20 (musl 1.2.5). Ver comentário acima.
+FROM node:22-alpine3.20 AS production
 
 # yt-dlp version to bake — override at build time with --build-arg YTDLP_VERSION=...
 ARG YTDLP_VERSION=2026.06.09

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,9 @@ COPY src/ ./src/
 
 RUN npm run build
 
+# Prune dev deps in-place so node_modules is production-only (incl. compiled native addons)
+RUN npm prune --omit=dev
+
 # ── production stage ────────────────────────────────────────────────────────────
 FROM node:22-alpine AS production
 
@@ -28,7 +31,8 @@ ARG YTDLP_VERSION=2026.06.09
 #   ffmpeg        — audio transcoding
 #   python3/pip   — needed to install yt-dlp from PyPI (arch-agnostic, always latest)
 #   su-exec       — privilege-drop in entrypoint
-RUN apk add --no-cache ffmpeg python3 py3-pip su-exec
+#   libstdc++     — required at runtime by @discordjs/opus compiled from source (musl build)
+RUN apk add --no-cache ffmpeg python3 py3-pip su-exec libstdc++
 
 # Install yt-dlp via pip (supports both linux/amd64 and linux/arm64 transparently).
 # --break-system-packages is required on Alpine ≥3.20 (PEP-668 enforced).
@@ -37,7 +41,9 @@ RUN pip install --no-cache-dir --break-system-packages "yt-dlp==${YTDLP_VERSION}
 
 WORKDIR /app
 COPY package*.json ./
-RUN npm ci --only=production && npm cache clean --force
+# node_modules (incl. @discordjs/opus compiled for musl) come from the builder stage.
+# No npm ci here — avoids recompiling native addons without build tools.
+COPY --from=builder /app/node_modules ./node_modules
 COPY --from=builder /app/dist ./dist
 # Fallback asset used in embeds
 COPY musa.png ./


### PR DESCRIPTION
## Causa raiz

O PR #3 bumpeou Node 18→22 (ABI v127). O \`@discordjs/opus@0.10.0\` **não tem prebuild para Node 22 + musl/Alpine** — o \`node-pre-gyp\` dá 404 e cai para compilar do source com \`node-gyp\`. No Node 18 existia prebuild musl, então nunca compilava e o problema estava oculto.

O stage de **produção** rodava \`npm ci --only=production\` mas **não tem \`make\`/\`g++\`** — resultado: \`gyp ERR! stack Error: not found: make\`. O CI falhou a cada build desde o merge do #3.

> **Update (2026-06-14) — causa raiz refinada após validação arm64:**
>
> A análise acima estava incompleta. Mesmo adicionando build tools ao stage de produção, o build multi-arch continuaria quebrando em **arm64** por uma razão diferente:
>
> A tag flutuante \`node:22-alpine\` avançou para **Alpine 3.21**, que ships **musl 1.2.6**. O \`@discordjs/opus@0.10.0\` só publica prebuild para \`node-v127 + musl-1.2.5\`. Com musl 1.2.6, o \`node-pre-gyp\` recebe 404 no download do prebuild, tenta compilar libopus do source — e encontra um **bug de compilação ARM NEON** (\`implicit declaration of function 'celt_inner_prod_neon'\`) que só se manifesta em arm64.
>
> O fix definitivo é **pinar Alpine 3.20** (que ships musl 1.2.5) nas duas base images, fazendo o prebuild casar exatamente.

## Fix

**Stage \`builder\`** (que já tem \`g++\`/\`make\`/\`python3\`):
- Após \`npm run build\`, adicionado \`RUN npm prune --omit=dev\` — poda as dev deps in-place, deixando \`node_modules\` com apenas produção e com o \`opus.node\` já compilado para a arch correta.

**Stage \`production\`**:
- Removido \`npm ci --only=production && npm cache clean --force\` — sem recompilação, sem compilador necessário.
- Adicionado \`COPY --from=builder /app/node_modules ./node_modules\` — traz o \`node_modules\` pronto (incl. \`@discordjs/opus\` compilado para musl).
- Adicionado \`libstdc++\` ao \`apk add\` — o \`opus.node\` compilado do source linka contra \`libstdc++\` em runtime; Alpine musl não inclui por padrão.
- **Base images pinadas em \`node:22-alpine3.20\`** (musl 1.2.5) em ambos os stages para garantir match com o prebuild do opus.

## Por que funciona para multi-arch (amd64 + arm64)

O buildx compila cada plataforma em seu próprio builder. O \`npm prune --omit=dev\` e o \`COPY --from=builder\` acontecem dentro da mesma plataforma — o \`opus.node\` é compilado para a arch certa (amd64 ou arm64 musl) e copiado diretamente. Não há cross-arch mixing.

Com Alpine 3.20 pinado, o prebuild musl-1.2.5 é encontrado pelo \`node-pre-gyp\`, baixado pronto — zero compilação de source, zero exposição ao bug ARM NEON.

## Validação

- \`npm run build\` (tsc): verde, zero erros
- \`npm run lint\`: falha pré-existente de config do \`@typescript-eslint\` (incompatibilidade de versão no \`.eslintrc.js\`) — não regressão deste PR
- **Build arm64 validado manualmente na VM Oracle ARM (aarch64):** \`BUILD OK\`, \`@discordjs/opus\` carrega sem erros, \`yt-dlp 2026.06.09\`, \`node v22.16.0\`
- \`docker build\` no CI: validação multi-arch delegada ao \`deploy.yml\` no merge

## Diff resumido

\`\`\`dockerfile
# builder stage — base image pinada + prune após build:
- FROM node:22-alpine AS builder
+ FROM node:22-alpine3.20 AS builder   # Pin musl 1.2.5 — ver comentário no Dockerfile
+ RUN npm prune --omit=dev

# production stage — base image pinada + substituição do npm ci:
- FROM node:22-alpine AS production
+ FROM node:22-alpine3.20 AS production  # Pin musl 1.2.5 — ver comentário no Dockerfile
- RUN apk add --no-cache ffmpeg python3 py3-pip su-exec
+ RUN apk add --no-cache ffmpeg python3 py3-pip su-exec libstdc++
- COPY package*.json ./
- RUN npm ci --only=production && npm cache clean --force
- COPY --from=builder /app/dist ./dist
+ COPY package*.json ./
+ COPY --from=builder /app/node_modules ./node_modules
+ COPY --from=builder /app/dist ./dist
\`\`\`

---
Built by VHXCO Agentic Software House