### PR TITLE
fix: route yt-dlp search through WARP proxy + fix CI test load

### DIFF
--- a/src/services/ResolverYouTubeService.ts
+++ b/src/services/ResolverYouTubeService.ts
@@ -185,12 +185,19 @@ export class ResolverYouTubeService extends BaseMusicService {
             ytDlpArgs.splice(-1, 0, '--extractor-args', 'youtube:player_client=default');
           }
 
+          // Add proxy if configured — direct fallback must route through WARP too
+          const searchProxy = botConfig.ytdlpProxy;
+          if (searchProxy) {
+            ytDlpArgs.splice(-1, 0, '--proxy', searchProxy);
+          }
+
           logEvent('resolver_youtube_ytdlp_command', {
             command: 'yt-dlp',
             args: ytDlpArgs.join(' '),
             query,
             method: 'direct_ytdlp',
             engine,
+            hasProxy: !!searchProxy,
           });
 
           const ytDlp = spawn('yt-dlp', ytDlpArgs);
@@ -428,11 +435,18 @@ export class ResolverYouTubeService extends BaseMusicService {
         logEvent('resolver_ytdlp_stream_no_cookies', { url });
       }
 
+      // Add proxy if configured — direct fallback must route through WARP too
+      const streamProxy = botConfig.ytdlpProxy;
+      if (streamProxy) {
+        ytDlpArgs.splice(-1, 0, '--proxy', streamProxy);
+      }
+
       logEvent('resolver_youtube_ytdlp_stream_command', {
         command: 'yt-dlp',
         args: ytDlpArgs.join(' '),
         url,
         method: 'direct_ytdlp',
+        hasProxy: !!streamProxy,
       });
 
       const ytDlp = spawn('yt-dlp', ytDlpArgs);

--- a/src/services/YouTubeService.ts
+++ b/src/services/YouTubeService.ts
@@ -125,6 +125,12 @@ export class YouTubeService extends BaseMusicService {
         ytDlpArgs.push('--extractor-args', 'youtube:player_client=default');
       }
 
+      // Add proxy if configured — search must go through WARP just like stream/pipe
+      const searchProxy = botConfig.ytdlpProxy;
+      if (searchProxy) {
+        ytDlpArgs.push('--proxy', searchProxy);
+      }
+
       // Add the search query
       ytDlpArgs.push(searchQuery);
 
@@ -133,6 +139,7 @@ export class YouTubeService extends BaseMusicService {
         args: ytDlpArgs.join(' '),
         query,
         engine,
+        hasProxy: !!searchProxy,
       });
 
       const ytDlp = spawn('yt-dlp', ytDlpArgs);

--- a/tests/musicManager.test.js
+++ b/tests/musicManager.test.js
@@ -1,5 +1,63 @@
 /* Basic unit tests for MusicManager using compiled JS from dist */
 
+// @discordjs/voice pulls in @snazzah/davey (native module) which doesn't load
+// in the CI/jest environment. Mock the whole package with the subset that
+// MusicManager actually uses so the module graph loads cleanly without any
+// native bindings.
+jest.mock('@discordjs/voice', () => {
+  const AudioPlayerStatus = {
+    Idle: 'idle',
+    Buffering: 'buffering',
+    Paused: 'paused',
+    Playing: 'playing',
+    AutoPaused: 'autopaused',
+  };
+
+  const VoiceConnectionStatus = {
+    Connecting: 'connecting',
+    Destroyed: 'destroyed',
+    Disconnected: 'disconnected',
+    Ready: 'ready',
+    Signalling: 'signalling',
+  };
+
+  const StreamType = {
+    Arbitrary: 'arbitrary',
+    OggOpus: 'ogg/opus',
+    WebmOpus: 'webm/opus',
+    Raw: 'raw',
+    OggVorbis: 'ogg/vorbis',
+  };
+
+  const mockPlayer = {
+    on: jest.fn().mockReturnThis(),
+    play: jest.fn(),
+    stop: jest.fn(),
+    pause: jest.fn(),
+    unpause: jest.fn(),
+    state: { status: AudioPlayerStatus.Idle },
+  };
+
+  const mockConnection = {
+    on: jest.fn().mockReturnThis(),
+    subscribe: jest.fn(() => ({ unsubscribe: jest.fn() })),
+    destroy: jest.fn(),
+    state: { status: VoiceConnectionStatus.Ready },
+  };
+
+  return {
+    AudioPlayerStatus,
+    VoiceConnectionStatus,
+    StreamType,
+    createAudioPlayer: jest.fn(() => mockPlayer),
+    createAudioResource: jest.fn((input, opts) => ({ playStream: input, metadata: opts?.metadata })),
+    joinVoiceChannel: jest.fn(() => mockConnection),
+    entersState: jest.fn(() => Promise.resolve(mockConnection)),
+    getVoiceConnection: jest.fn(() => undefined),
+    NoSubscriberBehavior: { Pause: 'pause', Play: 'play', Stop: 'stop' },
+  };
+});
+
 const { MusicManager } = require('../dist/services/MusicManager');
 
 function makeSong(title, url) {
@@ -32,9 +90,9 @@ describe('MusicManager basics', () => {
       makeSong('c', 'https://youtu.be/c'),
     ];
 
-    const before = data.queue.map(s => s.url).sort();
+    const before = data.queue.map((s) => s.url).sort();
     mm.shuffleQueue(gid);
-    const after = data.queue.map(s => s.url).sort();
+    const after = data.queue.map((s) => s.url).sort();
     expect(after).toEqual(before);
   });
 


### PR DESCRIPTION
## Problema

Duas issues independentes de estabilidade.

## Fix 1 — search não usava proxy WARP (causa: bot-detection em prod)

**Sintoma:** \`/play <url>\` tocava normalmente (passa pelo WARP), mas \`/play <termo>\` retornava \`Sign in to confirm you're not a bot\` porque a chamada de **busca** do yt-dlp saía pelo IP direto da VM (datacenter, bloqueado pelo YouTube).

**Causa:** das 3 invocações de \`yt-dlp\` em \`YouTubeService.ts\`, as de \`getStreamUrl\` e \`fetchMeta\` já adicionavam \`--proxy botConfig.ytdlpProxy\`, mas \`searchWithYtDlp\` **não adicionava**. Mesmo gap existia no fallback direto do \`ResolverYouTubeService.ts\` (\`searchWithDirectYtDlp\` e \`getStreamUrlWithDirectYtDlp\`).

**Paths corrigidos:**
- \`YouTubeService.searchWithYtDlp\` — proxy adicionado antes da search query
- \`ResolverYouTubeService.searchWithDirectYtDlp\` — proxy adicionado no array de args (splice antes do termo)
- \`ResolverYouTubeService.getStreamUrlWithDirectYtDlp\` — proxy adicionado antes da URL

**Paths auditados e confirmados já corretos (não alterados):**
- \`YouTubeService.getStreamUrl\` — já tinha \`--proxy\`
- \`YouTubeService.fetchMeta\` — já tinha \`--proxy\`
- \`YouTubeService.spawnPipeStream\` — já tinha \`--proxy\`
- \`YouTubePlaylistProvider.fetchItems\` — já tinha \`--proxy\`

Não há nova env var. A lógica é a mesma: \`if (botConfig.ytdlpProxy) args.push('--proxy', proxy)\`.

## Fix 2 — CI verde: mock do @discordjs/voice no teste

**Sintoma:** \`Run tests\` no CI falha porque \`tests/musicManager.test.js\` carrega \`dist/services/MusicManager\` que importa \`@discordjs/voice@0.19\` → \`DAVESession\` → módulo nativo \`@snazzah/davey\`, que não carrega no runner do jest (só funciona no ARM de prod).

**Fix:** \`jest.mock('@discordjs/voice', ...)\` no topo de \`musicManager.test.js\` com todos os exports que o MusicManager usa:
- \`AudioPlayerStatus\`, \`VoiceConnectionStatus\`, \`StreamType\` (enums como objetos)
- \`createAudioPlayer\`, \`createAudioResource\`, \`joinVoiceChannel\`, \`entersState\`, \`getVoiceConnection\`, \`NoSubscriberBehavior\` (funções/mocks)

As asserções existentes continuam íntegras — o mock não muda o que é testado (estado da fila, shuffle, \`isConnected\`).

**Resultado:** 8/8 testes passando.

## Validação

- \`npm run build\` — verde
- \`npm run typecheck\` — verde (zero erros)
- \`npm run lint\` — verde (0 errors, warnings preexistentes de \`any\` no codebase, nenhum novo)
- \`npm test\` — 8/8 testes passando (2 suites)

## Test plan

- [ ] Em prod: \`/play bohemian rhapsody\` (busca por termo) deve tocar sem erro de bot-detection
- [ ] Em prod: \`/play https://youtu.be/...\` (URL direta) continua funcionando (não alterado)
- [ ] CI: \`Run tests\` deve passar verde agora

---
Built by VHXCO Agentic Software House