### PR TITLE
chore: remove dead code (PR-A — safe deletes)

### DIFF
--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -1,9 +1,0 @@
-export { default as play } from './play';
-export { default as pause } from './pause';
-export { default as resume } from './resume';
-export { default as stop } from './stop';
-export { default as skip } from './skip';
-export { default as queue } from './queue';
-export { default as radio } from './radio';
-export { default as shuffle } from './shuffle';
-export { default as playlist } from './playlist';

--- a/src/events/index.ts
+++ b/src/events/index.ts
@@ -1,3 +1,0 @@
-export { default as ready } from './ready';
-export { default as interactionCreate } from './interactionCreate';
-export { default as voiceStateUpdate } from './voiceStateUpdate';

--- a/src/services/Announcer.ts
+++ b/src/services/Announcer.ts
@@ -3,7 +3,14 @@ import path from 'path';
 import fs from 'fs';
 import { botConfig } from '../config';
 import { logEvent, logError } from '../utils/logger';
-import { createMusaEmbed, getRandomPhrase, MusaColors, MusaEmojis, truncateText, formatDuration } from '../utils/discord';
+import {
+  createMusaEmbed,
+  getRandomPhrase,
+  MusaColors,
+  MusaEmojis,
+  truncateText,
+  formatDuration,
+} from '../utils/discord';
 import { QueuedSong } from '../types/music';
 
 class AnnouncerImpl {
@@ -14,15 +21,18 @@ class AnnouncerImpl {
     this.client = client;
   }
 
-  async updateGuildStatus(guildId: string, data: {
-    currentSong: QueuedSong | null;
-    queue: QueuedSong[];
-    voiceChannelName?: string;
-    voiceChannelId?: string;
-    startedAt?: number; // epoch ms
-    recent?: QueuedSong[];
-    lastShuffle?: { by: string; at: number };
-  }) {
+  async updateGuildStatus(
+    guildId: string,
+    data: {
+      currentSong: QueuedSong | null;
+      queue: QueuedSong[];
+      voiceChannelName?: string;
+      voiceChannelId?: string;
+      startedAt?: number; // epoch ms
+      recent?: QueuedSong[];
+      lastShuffle?: { by: string; at: number };
+    },
+  ) {
     try {
       if (!this.client) return;
       const channelId = botConfig.musaChannelId;
@@ -37,7 +47,9 @@ class AnnouncerImpl {
         try {
           const vc = await this.client.channels.fetch(data.voiceChannelId);
           if (vc && 'name' in vc) data.voiceChannelName = (vc as any).name as string;
-        } catch { /* ignore */ }
+        } catch {
+          /* ignore */
+        }
       }
 
       const embed = await this.buildStatusEmbed(data);
@@ -68,10 +80,18 @@ class AnnouncerImpl {
           const opts: any = { limit: 100 };
           if (before) opts.before = before;
           const page: any = await textChannel.messages.fetch(opts);
-          const list: any[] = page && typeof page.values === 'function' ? Array.from(page.values()) : Array.isArray(page) ? page : page ? [page] : [];
+          const list: any[] =
+            page && typeof page.values === 'function'
+              ? Array.from(page.values())
+              : Array.isArray(page)
+                ? page
+                : page
+                  ? [page]
+                  : [];
           const existing = list.find((m) => m?.author?.id === botId);
           if (existing) {
-            if (files) await existing.edit({ embeds: [embed], files }); else await existing.edit({ embeds: [embed] });
+            if (files) await existing.edit({ embeds: [embed], files });
+            else await existing.edit({ embeds: [embed] });
             this.lastNowPlayingMessageIdByGuild.set(guildId, existing.id);
             logEvent('status_message_reused', { guildId, messageId: existing.id, page: i });
             return;
@@ -80,7 +100,9 @@ class AnnouncerImpl {
           if (!oldest?.id) break;
           before = oldest.id as string;
         }
-      } catch { /* ignore */ }
+      } catch {
+        /* ignore */
+      }
 
       const sent = await textChannel.send(files ? { embeds: [embed], files } : { embeds: [embed] });
       this.lastNowPlayingMessageIdByGuild.set(guildId, sent.id);
@@ -89,8 +111,6 @@ class AnnouncerImpl {
       logError('update_guild_status_failed', error as Error, { guildId });
     }
   }
-
-  // Pinning disabled per latest request; keeping method removed.
 
   private async buildStatusEmbed(data: {
     currentSong: QueuedSong | null;
@@ -103,10 +123,12 @@ class AnnouncerImpl {
     const fields: { name: string; value: string; inline?: boolean }[] = [];
     const base: any = {
       title: data.currentSong ? 'Tocando Agora' : 'Silêncio Encantado',
-      description: data.currentSong ? (getRandomPhrase('playing') || `${MusaEmojis.notes} Tocando com carinho!`) : (getRandomPhrase('idle') || `${MusaEmojis.mute || '🔇'} Em silêncio...`),
+      description: data.currentSong
+        ? getRandomPhrase('playing') || `${MusaEmojis.notes} Tocando com carinho!`
+        : getRandomPhrase('idle') || `${MusaEmojis.mute || '🔇'} Em silêncio...`,
       color: data.currentSong ? MusaColors.nowPlaying : MusaColors.warning,
       fields,
-      timestamp: true
+      timestamp: true,
     };
 
     // Now playing block
@@ -114,13 +136,32 @@ class AnnouncerImpl {
     if (data.currentSong) {
       const s = data.currentSong;
       fields.push({ name: `${MusaEmojis.notes} Música`, value: truncateText(s.title, 70), inline: false });
-      if (s.creator) fields.push({ name: `${MusaEmojis.microphone} Artista`, value: truncateText(s.creator, 40), inline: true });
-      if (s.requestedBy) fields.push({ name: `${MusaEmojis.fairy} Adicionada por`, value: truncateText(s.requestedBy, 30), inline: true });
-      if (data.voiceChannelName) fields.push({ name: `${MusaEmojis.headphones} Canal de Voz`, value: data.voiceChannelName, inline: true });
+      if (s.creator)
+        fields.push({
+          name: `${MusaEmojis.microphone} Artista`,
+          value: truncateText(s.creator, 40),
+          inline: true,
+        });
+      if (s.requestedBy)
+        fields.push({
+          name: `${MusaEmojis.fairy} Adicionada por`,
+          value: truncateText(s.requestedBy, 30),
+          inline: true,
+        });
+      if (data.voiceChannelName)
+        fields.push({
+          name: `${MusaEmojis.headphones} Canal de Voz`,
+          value: data.voiceChannelName,
+          inline: true,
+        });
 
       // Show only total duration (no live progress)
       if (typeof s.duration === 'number' && s.duration > 0) {
-        fields.push({ name: `${MusaEmojis.cd} Duração`, value: `${formatDuration(s.duration)}`, inline: true });
+        fields.push({
+          name: `${MusaEmojis.cd} Duração`,
+          value: `${formatDuration(s.duration)}`,
+          inline: true,
+        });
       }
 
       // Thumbnail or fallback attachment
@@ -146,8 +187,11 @@ class AnnouncerImpl {
     });
     fields.push({
       name: `${MusaEmojis.queue} Próximas Músicas (${data.queue.length})`,
-      value: lines.length > 0 ? lines.join('\n') : `${MusaEmojis.search} A fila está vazia — use /play para adicionar músicas!`,
-      inline: false
+      value:
+        lines.length > 0
+          ? lines.join('\n')
+          : `${MusaEmojis.search} A fila está vazia — use /play para adicionar músicas!`,
+      inline: false,
     });
 
     // Last shuffle info (if available)
@@ -158,7 +202,7 @@ class AnnouncerImpl {
       fields.push({
         name: `${MusaEmojis.shuffle} Último Shuffle`,
         value: `por ${data.lastShuffle.by} • ${hh}:${mm}`,
-        inline: true
+        inline: true,
       });
     }
 
@@ -173,7 +217,9 @@ class AnnouncerImpl {
         try {
           const u = await this.client.users.fetch(lastAdded.byId);
           base.footerIconUrl = u.displayAvatarURL({ size: 64 });
-        } catch { /* ignore */ }
+        } catch {
+          /* ignore */
+        }
       }
     }
 
@@ -189,81 +235,11 @@ class AnnouncerImpl {
       embed.addFields({
         name: `${MusaEmojis.cd} Já Tocaram (${recent.length})`,
         value: linesRecent.join('\n'),
-        inline: false
+        inline: false,
       });
     }
     if (files) (embed as any).__files = files;
     return embed;
-  }
-
-  async announceNowPlaying(guildId: string, song: QueuedSong, voiceChannelId?: string, thumbnail?: string) {
-    try {
-      if (!this.client) return;
-      const channelId = botConfig.musaChannelId;
-      if (!channelId) return;
-
-      const channel = await this.client.channels.fetch(channelId);
-      if (!channel || !channel.isTextBased()) return;
-      const textChannel = channel as TextChannel;
-
-      // Resolve voice channel name if possible
-      let voiceName = '';
-      if (voiceChannelId) {
-        try {
-          const vc = await this.client.channels.fetch(voiceChannelId);
-          if (vc && 'name' in vc) voiceName = (vc as any).name as string;
-        } catch { /* ignore */ }
-      }
-
-      const description = getRandomPhrase('playing') || `${MusaEmojis.notes} Tocando com carinho!`;
-      const base: any = {
-        title: 'Tocando Agora',
-        description,
-        color: MusaColors.nowPlaying,
-        fields: [
-          { name: `${MusaEmojis.notes} Música`, value: truncateText(song.title, 70), inline: false },
-          ...(voiceName ? [{ name: `${MusaEmojis.microphone} Canal de Voz`, value: voiceName, inline: true }] : [])
-        ],
-        timestamp: true
-      };
-      const thumb = thumbnail || (song as any).thumbnail as string | undefined;
-
-      // Prepare optional attachment for fallback thumbnail (musa.png)
-      let files: Array<{ attachment: string; name?: string }> | undefined;
-      if (thumb) {
-        base.thumbnail = thumb;
-      } else {
-        const fallbackPath = path.resolve(process.cwd(), 'musa.png');
-        if (fs.existsSync(fallbackPath)) {
-          base.thumbnail = 'attachment://musa.png';
-          files = [{ attachment: fallbackPath, name: 'musa.png' }];
-        }
-      }
-      const embed: EmbedBuilder = createMusaEmbed(base);
-
-      // Edit previous now-playing message if exists
-      const lastId = this.lastNowPlayingMessageIdByGuild.get(guildId);
-      if (lastId) {
-        try {
-          const msg = await textChannel.messages.fetch(lastId);
-          if (files) {
-            await msg.edit({ embeds: [embed], files });
-          } else {
-            await msg.edit({ embeds: [embed] });
-          }
-          logEvent('now_playing_edited', { guildId, messageId: lastId });
-          return;
-        } catch {
-          // If fetch/edit fails, fall back to sending a new message
-        }
-      }
-
-      const sent = await textChannel.send(files ? { embeds: [embed], files } : { embeds: [embed] });
-      this.lastNowPlayingMessageIdByGuild.set(guildId, sent.id);
-      logEvent('now_playing_sent', { guildId, messageId: sent.id });
-    } catch (error) {
-      logError('announce_now_playing_failed', error as Error, { guildId, title: song.title });
-    }
   }
 }
 

--- a/src/services/BaseMusicService.ts
+++ b/src/services/BaseMusicService.ts
@@ -12,7 +12,7 @@ export abstract class BaseMusicService {
   }
 
   abstract search(query: string, maxResults?: number): Promise<MusicSource[]>;
-  
+
   isEnabled(): boolean {
     return this.enabled;
   }
@@ -55,19 +55,7 @@ export abstract class BaseMusicService {
     return source;
   }
 
-  protected validateUrl(url: string): boolean {
-    try {
-      new URL(url);
-      return true;
-    } catch {
-      return false;
-    }
-  }
-
   protected cleanTitle(title: string): string {
-    return title
-      .replace(/[[\]]/g, '')
-      .replace(/\s+/g, ' ')
-      .trim();
+    return title.replace(/[[\]]/g, '').replace(/\s+/g, ' ').trim();
   }
 }

--- a/src/services/PresenceManager.ts
+++ b/src/services/PresenceManager.ts
@@ -11,10 +11,6 @@ class PresenceManagerImpl {
     this.client = client;
   }
 
-  setIdleInterval(minutes: number) {
-    this.idleIntervalMs = Math.max(60_000, Math.floor(minutes * 60 * 1000));
-  }
-
   updatePlayingPresence(text: string) {
     if (!this.client?.user) return;
     // Cancel idle cycling if any
@@ -22,9 +18,11 @@ class PresenceManagerImpl {
     try {
       this.client.user.setPresence({
         status: 'online',
-        activities: [{ name: text, type: ActivityType.Listening }]
+        activities: [{ name: text, type: ActivityType.Listening }],
       });
-    } catch { /* ignore */ }
+    } catch {
+      /* ignore */
+    }
     logEvent('presence_playing_set', { text });
   }
 
@@ -35,9 +33,11 @@ class PresenceManagerImpl {
       try {
         this.client!.user!.setPresence({
           status: 'idle',
-          activities: [{ name: phrase, type: ActivityType.Listening }]
+          activities: [{ name: phrase, type: ActivityType.Listening }],
         });
-      } catch { /* ignore */ }
+      } catch {
+        /* ignore */
+      }
       logEvent('presence_idle_set', { phrase });
     };
     // Set immediately and then cycle

--- a/src/services/RadioService.ts
+++ b/src/services/RadioService.ts
@@ -16,81 +16,81 @@ export class RadioService extends BaseMusicService {
         name: 'Pop Hits Radio',
         url: 'https://ice.somafm.com/poptron-128-mp3',
         genre: 'pop',
-        country: 'US'
+        country: 'US',
       },
       {
-        name: 'Today\'s Hits',
+        name: "Today's Hits",
         url: 'https://ice.somafm.com/indiepop-128-mp3',
         genre: 'pop',
-        country: 'US'
-      }
+        country: 'US',
+      },
     ],
     rock: [
       {
         name: 'Classic Rock Radio',
         url: 'https://ice.somafm.com/bootliquor-128-mp3',
         genre: 'rock',
-        country: 'US'
+        country: 'US',
       },
       {
         name: 'Rock Hits',
         url: 'https://ice.somafm.com/folkfwd-128-mp3',
         genre: 'rock',
-        country: 'US'
-      }
+        country: 'US',
+      },
     ],
     jazz: [
       {
         name: 'Smooth Jazz',
         url: 'https://ice.somafm.com/groovesalad-128-mp3',
         genre: 'jazz',
-        country: 'US'
+        country: 'US',
       },
       {
         name: 'Jazz24',
         url: 'https://ice.somafm.com/thetrip-128-mp3',
         genre: 'jazz',
-        country: 'US'
-      }
+        country: 'US',
+      },
     ],
     classical: [
       {
         name: 'Classical Music',
         url: 'https://ice.somafm.com/sonicuniverse-128-mp3',
         genre: 'classical',
-        country: 'US'
-      }
+        country: 'US',
+      },
     ],
     electronic: [
       {
         name: 'Electronic Beats',
         url: 'https://ice.somafm.com/beatblender-128-mp3',
         genre: 'electronic',
-        country: 'US'
+        country: 'US',
       },
       {
         name: 'Drone Zone',
         url: 'https://ice.somafm.com/dronezone-128-mp3',
         genre: 'electronic',
-        country: 'US'
-      }
+        country: 'US',
+      },
     ],
     chill: [
       {
         name: 'Chill Out',
         url: 'https://ice.somafm.com/groovesalad-128-mp3',
         genre: 'chill',
-        country: 'US'
-      }
+        country: 'US',
+      },
     ],
     lofi: [
       {
         name: 'Lo-Fi Hip Hop',
         url: 'https://ice.somafm.com/beatblender-128-mp3',
         genre: 'lofi',
-        country: 'US'
-      }
-    ]
+        country: 'US',
+      },
+    ],
   };
 
   constructor(priority: number, enabled: boolean) {
@@ -114,19 +114,19 @@ export class RadioService extends BaseMusicService {
         return [];
       }
 
-      const results = stations
-        .slice(0, maxResults)
-        .map(station => this.createMusicSource({
+      const results = stations.slice(0, maxResults).map((station) =>
+        this.createMusicSource({
           title: `📻 ${station.name} (${station.genre.toUpperCase()})`,
           url: station.url,
           creator: 'Live Radio',
           isLiveStream: true,
-        }));
+        }),
+      );
 
-      logEvent('radio_search_completed', { 
-        genre, 
-        stationsFound: stations.length, 
-        resultsReturned: results.length 
+      logEvent('radio_search_completed', {
+        genre,
+        stationsFound: stations.length,
+        resultsReturned: results.length,
       });
 
       return results;
@@ -138,9 +138,5 @@ export class RadioService extends BaseMusicService {
 
   getAvailableGenres(): string[] {
     return Object.keys(this.radioStations);
-  }
-
-  getStationsByGenre(genre: string): RadioStation[] {
-    return this.radioStations[genre.toLowerCase()] || [];
   }
 }

--- a/src/services/ResolverYouTubeService.ts
+++ b/src/services/ResolverYouTubeService.ts
@@ -509,12 +509,6 @@ export class ResolverYouTubeService extends BaseMusicService {
     });
   }
 
-  validateUrl(url: string): boolean {
-    // Basic YouTube URL validation
-    const youtubeRegex = /^(https?:\/\/)?(www\.)?(youtube\.com|youtu\.be)\/.+/;
-    return youtubeRegex.test(url);
-  }
-
   // Health check method
   async isResolverHealthy(): Promise<boolean> {
     try {

--- a/src/services/YouTubeService.ts
+++ b/src/services/YouTubeService.ts
@@ -374,12 +374,6 @@ export class YouTubeService extends BaseMusicService {
     }
   }
 
-  validateUrl(url: string): boolean {
-    // Basic YouTube URL validation
-    const youtubeRegex = /^(https?:\/\/)?(www\.)?(youtube\.com|youtu\.be)\/.+/;
-    return youtubeRegex.test(url);
-  }
-
   // Fetch basic metadata (thumbnail/creator/duration) for a YouTube video URL
   async fetchMeta(videoUrl: string): Promise<{
     title?: string;

--- a/src/services/index.ts
+++ b/src/services/index.ts
@@ -1,5 +1,0 @@
-export * from './BaseMusicService';
-export * from './RadioService';
-export * from './InternetArchiveService';
-export * from './MultiSourceManager';
-export * from './MusicManager';

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,2 +1,0 @@
-export * from './logger';
-export * from './discord';

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -10,32 +10,29 @@ const logger = winston.createLogger({
     winston.format.printf(({ timestamp, level, message, ...meta }) => {
       const metaString = Object.keys(meta).length ? JSON.stringify(meta, null, 2) : '';
       return `${timestamp} [${level.toUpperCase()}]: ${message} ${metaString}`;
-    })
+    }),
   ),
   transports: [
     new winston.transports.Console({
-      format: winston.format.combine(
-        winston.format.colorize(),
-        winston.format.simple()
-      )
+      format: winston.format.combine(winston.format.colorize(), winston.format.simple()),
     }),
     new winston.transports.File({
       filename: 'logs/error.log',
       level: 'error',
       ...(botConfig.logging.maxSizeBytes !== undefined ? { maxsize: botConfig.logging.maxSizeBytes } : {}),
-      ...(botConfig.logging.maxFiles !== undefined ? { maxFiles: botConfig.logging.maxFiles } : {})
+      ...(botConfig.logging.maxFiles !== undefined ? { maxFiles: botConfig.logging.maxFiles } : {}),
     }),
     new winston.transports.File({
       filename: 'logs/combined.log',
       ...(botConfig.logging.maxSizeBytes !== undefined ? { maxsize: botConfig.logging.maxSizeBytes } : {}),
-      ...(botConfig.logging.maxFiles !== undefined ? { maxFiles: botConfig.logging.maxFiles } : {})
-    })
-  ]
+      ...(botConfig.logging.maxFiles !== undefined ? { maxFiles: botConfig.logging.maxFiles } : {}),
+    }),
+  ],
 });
 
 export const logEvent = (event: string, meta?: Record<string, unknown>): void => {
   const musicalEvent = `🎵 ${event}`;
-  
+
   if (meta) {
     logger.info(musicalEvent, meta);
   } else {
@@ -45,13 +42,13 @@ export const logEvent = (event: string, meta?: Record<string, unknown>): void =>
 
 export const logError = (message: string, error?: Error, meta?: Record<string, unknown>): void => {
   const musicalError = `🎵💥 ${message}`;
-  
+
   const errorMeta = {
     ...meta,
     ...(error && {
       error: error.message,
-      stack: error.stack
-    })
+      stack: error.stack,
+    }),
   };
 
   logger.error(musicalError, errorMeta);
@@ -59,21 +56,11 @@ export const logError = (message: string, error?: Error, meta?: Record<string, u
 
 export const logWarning = (message: string, meta?: Record<string, unknown>): void => {
   const musicalWarning = `🎵⚠️ ${message}`;
-  
+
   if (meta) {
     logger.warn(musicalWarning, meta);
   } else {
     logger.warn(musicalWarning);
-  }
-};
-
-export const logDebug = (message: string, meta?: Record<string, unknown>): void => {
-  const musicalDebug = `🎵🔍 ${message}`;
-  
-  if (meta) {
-    logger.debug(musicalDebug, meta);
-  } else {
-    logger.debug(musicalDebug);
   }
 };
 

--- a/src/utils/providers.ts
+++ b/src/utils/providers.ts
@@ -5,29 +5,19 @@ export interface DetectedUrlInfo {
   provider: Provider;
   kind: ContentKind;
   // Normalized identifiers when detectable
-  videoId?: string;       // YouTube/YouTube Music video id
-  playlistId?: string;    // YouTube/YouTube Music playlist id (same as listId)
-  listId?: string;        // alias for playlistId
-  trackId?: string;       // Spotify track id
-  albumId?: string;       // Spotify album id (not used yet)
+  videoId?: string; // YouTube/YouTube Music video id
+  playlistId?: string; // YouTube/YouTube Music playlist id (same as listId)
+  listId?: string; // alias for playlistId
+  trackId?: string; // Spotify track id
+  albumId?: string; // Spotify album id (not used yet)
   spotifyPlaylistId?: string; // Spotify playlist id
 }
 
-const YT_HOSTS = new Set([
-  'youtube.com',
-  'www.youtube.com',
-  'm.youtube.com',
-  'youtu.be',
-]);
+const YT_HOSTS = new Set(['youtube.com', 'www.youtube.com', 'm.youtube.com', 'youtu.be']);
 
-const YTM_HOSTS = new Set([
-  'music.youtube.com',
-  'www.music.youtube.com',
-]);
+const YTM_HOSTS = new Set(['music.youtube.com', 'www.music.youtube.com']);
 
-const SPOTIFY_HOSTS = new Set([
-  'open.spotify.com',
-]);
+const SPOTIFY_HOSTS = new Set(['open.spotify.com']);
 
 function safeParseUrl(input: string): URL | null {
   try {
@@ -43,28 +33,6 @@ function safeParseUrl(input: string): URL | null {
 
 function getHost(url: URL): string {
   return url.hostname.toLowerCase();
-}
-
-// Public helpers (useful across commands/services)
-export function isYouTubeUrl(input: string): boolean {
-  const u = safeParseUrl(input);
-  if (!u) return false;
-  const h = getHost(u);
-  return YT_HOSTS.has(h);
-}
-
-export function isYouTubeMusicUrl(input: string): boolean {
-  const u = safeParseUrl(input);
-  if (!u) return false;
-  const h = getHost(u);
-  return YTM_HOSTS.has(h);
-}
-
-export function isSpotifyUrl(input: string): boolean {
-  const u = safeParseUrl(input);
-  if (!u) return false;
-  const h = getHost(u);
-  return SPOTIFY_HOSTS.has(h);
 }
 
 export function isYouTubeVideoUrl(input: string): boolean {
@@ -88,36 +56,6 @@ export function isYouTubeVideoUrl(input: string): boolean {
   return false;
 }
 
-export function isYouTubePlaylistUrl(input: string): boolean {
-  const u = safeParseUrl(input);
-  if (!u) return false;
-  const h = getHost(u);
-  if (!YT_HOSTS.has(h)) return false;
-  const list = u.searchParams.get('list');
-  return (u.pathname === '/playlist' && !!list) || (!!list && u.pathname === '/watch');
-}
-
-export function isYouTubeMusicTrackUrl(input: string): boolean {
-  const u = safeParseUrl(input);
-  if (!u) return false;
-  const h = getHost(u);
-  if (!YTM_HOSTS.has(h)) return false;
-  if (u.pathname === '/watch') {
-    const v = u.searchParams.get('v');
-    return !!(v && v.length === 11);
-  }
-  return false;
-}
-
-export function isYouTubeMusicPlaylistUrl(input: string): boolean {
-  const u = safeParseUrl(input);
-  if (!u) return false;
-  const h = getHost(u);
-  if (!YTM_HOSTS.has(h)) return false;
-  const list = u.searchParams.get('list');
-  return (u.pathname === '/playlist' && !!list) || (!!list && u.pathname === '/watch');
-}
-
 function spotifyPathParts(u: URL): string[] {
   let parts = u.pathname.split('/').filter(Boolean);
   if (parts.length === 0) return parts;
@@ -128,24 +66,6 @@ function spotifyPathParts(u: URL): string[] {
     parts = parts.slice(1);
   }
   return parts;
-}
-
-export function isSpotifyPlaylistUrl(input: string): boolean {
-  const u = safeParseUrl(input);
-  if (!u) return false;
-  const h = getHost(u);
-  if (!SPOTIFY_HOSTS.has(h)) return false;
-  const parts = spotifyPathParts(u);
-  return parts[0] === 'playlist' && !!parts[1];
-}
-
-export function isSpotifyTrackUrl(input: string): boolean {
-  const u = safeParseUrl(input);
-  if (!u) return false;
-  const h = getHost(u);
-  if (!SPOTIFY_HOSTS.has(h)) return false;
-  const parts = spotifyPathParts(u);
-  return parts[0] === 'track' && !!parts[1];
 }
 
 export function detectProvider(input: string): Provider {
@@ -170,7 +90,8 @@ export function detectContentKind(input: string): ContentKind {
   if (YT_HOSTS.has(h)) {
     const list = u.searchParams.get('list');
     if ((u.pathname === '/playlist' && !!list) || (!!list && u.pathname === '/watch')) return 'playlist';
-    if (u.pathname === '/watch' || u.hostname === 'youtu.be' || u.pathname.startsWith('/shorts/')) return 'track';
+    if (u.pathname === '/watch' || u.hostname === 'youtu.be' || u.pathname.startsWith('/shorts/'))
+      return 'track';
   }
   if (SPOTIFY_HOSTS.has(h)) {
     const parts = spotifyPathParts(u);


### PR DESCRIPTION
## O que este PR faz

Remove dead code comprovado por `git grep` — zero call-sites em cada item antes de remover. Nenhuma mudança de comportamento.

## Itens removidos (confirmados com zero referência)

| Item | Arquivo(s) | Prova |
|------|-----------|-------|
| `validateUrl()` em 3 classes | `BaseMusicService.ts`, `YouTubeService.ts`, `ResolverYouTubeService.ts` | `git grep validateUrl` retorna só as 3 definições |
| `logDebug` | `src/utils/logger.ts` | `git grep logDebug` retorna só a definição |
| `RadioService.getStationsByGenre` | `src/services/RadioService.ts` | `git grep getStationsByGenre` retorna só a definição |
| `Announcer.announceNowPlaying` (~70 linhas) + tombstone comment | `src/services/Announcer.ts` | `git grep announceNowPlaying` retorna só a definição; supersedida por `updateGuildStatus` |
| `PresenceManager.setIdleInterval` | `src/services/PresenceManager.ts` | `git grep setIdleInterval` retorna só a definição |
| 8 exports de `utils/providers.ts` | `isYouTubeUrl`, `isYouTubeMusicUrl`, `isSpotifyUrl`, `isYouTubePlaylistUrl`, `isYouTubeMusicTrackUrl`, `isYouTubeMusicPlaylistUrl`, `isSpotifyPlaylistUrl`, `isSpotifyTrackUrl` | Zero import-sites. Hit em `MultiSourceManager.ts:108` é cópia inline local, não import. `spotifyPathParts` mantida (usada por `detectContentKind`/`analyzeUrl`). |
| 4 barrel files (`commands/index.ts`, `events/index.ts`, `utils/index.ts`, `services/index.ts`) | `src/` | Zero import-sites. Loader usa `fs.readdirSync` + filter de arquivos `index`. `services/index.ts` estava desatualizado (não listava YouTubeService etc.). |

## O que foi intencionalmente mantido (e por quê)

- `isYouTubeVideoUrl` em `providers.ts` — mantido para o PR-B que vai substituir as 3 cópias inline por import deste export
- `youtube-resolver/` e `ResolverYouTubeService` — dormentes de propósito (apenas o método `validateUrl` foi removido)
- `--no-check-certificate`, cookies, cache de stream-URL — são decisões de design (PR-C, aguarda Vitor)
- UA string duplicada — dedup fica no PR-B (mexe nos mesmos spots de args yt-dlp, evitar conflito de merge)

## Validação

- Typecheck: `tsc --noEmit` — **0 errors**
- Lint: `eslint src --ext .ts` — **0 errors** (76 warnings pré-existentes de `no-explicit-any`, nenhum novo)
- Tests: `jest --runInBand` — **8/8 pass**

---
Built by VHXCO Agentic Software House