### PR TITLE
fix(p0): 3 footguns isolados — RESOLVER_URL, fetchYouTubeMeta sem proxy, retries no pipe

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -51,7 +51,12 @@ LOG_LEVEL=INFO
 
 # YouTube Resolver Configuration (optional - for remote resolver)
 # If using docker compose with both services, prefer the service DNS name
-RESOLVER_URL=http://youtube-resolver:3001
+# ⚠️  DEIXE COMENTADO / VAZIO em produção.
+#     O caminho ativo de playback é YouTube direto via WARP (YTDLP_PROXY).
+#     Setar RESOLVER_URL ativa o ResolverYouTubeService (legado Pi-3, dormente)
+#     que NÃO implementa spawnPipeStream — todo playback YouTube vai quebrar com
+#     "spawnPipeStream not available".
+# RESOLVER_URL=http://youtube-resolver:3001
 
 # Bot Prefix (optional)
 PREFIX=!

--- a/src/commands/play.ts
+++ b/src/commands/play.ts
@@ -17,6 +17,7 @@ import { analyzeUrl, detectProvider, detectContentKind } from '../utils/provider
 import { SpotifyPlaylistProvider } from '../services/providers/SpotifyPlaylistProvider';
 import { TrackResolver } from '../services/TrackResolver';
 import { spawn } from 'child_process';
+import { buildYtDlpBaseArgs } from '../utils/ytdlp';
 
 export default {
   data: new SlashCommandBuilder()
@@ -343,7 +344,16 @@ export default {
   async fetchYouTubeMeta(videoUrl: string): Promise<any | null> {
     return new Promise((resolve) => {
       let output = '';
-      const args = ['--dump-json', '--no-warnings', '--skip-download', videoUrl];
+      // Use shared base args so this call goes through WARP proxy + UA,
+      // consistent with every other yt-dlp call-site. Without this the
+      // datacenter IP hits YouTube directly and gets bot-blocked.
+      const args = [
+        '--dump-json',
+        '--no-warnings',
+        '--skip-download',
+        ...buildYtDlpBaseArgs({ includeProxy: true, includeSocketTimeout: true }),
+        videoUrl,
+      ];
       const p = spawn('yt-dlp', args);
       p.stdout.on('data', (d) => {
         output += d.toString();

--- a/src/services/YouTubeService.ts
+++ b/src/services/YouTubeService.ts
@@ -306,6 +306,10 @@ export class YouTubeService extends BaseMusicService {
       '-', // write audio bytes to stdout
       '--quiet', // suppress progress bar (stderr still carries errors)
       '--no-warnings',
+      '--retries',
+      '10', // retry on transient network errors (e.g. WARP hiccups)
+      '--fragment-retries',
+      '10', // retry individual fragments before giving up the track
       ...buildYtDlpBaseArgs({ includeSocketTimeout: true, includeProxy: true }),
     ];
 
@@ -339,22 +343,20 @@ export class YouTubeService extends BaseMusicService {
 
     proc.on('exit', (code, signal) => {
       if (code !== 0 && signal !== 'SIGKILL') {
-        // Only log as error if not killed intentionally (SIGKILL = normal stop/skip)
-        if (stderrBuf.trim()) {
-          logError('youtube_pipe_stream_ytdlp_exit_nonzero', new Error(stderrBuf.trim()), {
+        // Any non-zero exit that wasn't an intentional SIGKILL is an error —
+        // always log at error level so it appears in error.log even when stderr
+        // is empty (silent failures are the hardest to debug).
+        logError(
+          'youtube_pipe_stream_ytdlp_exit_nonzero',
+          new Error(stderrBuf.trim() || `yt-dlp exited with code ${code}`),
+          {
             title: source.title,
             url: source.url,
             exitCode: code,
             signal,
-          });
-        } else {
-          logEvent('youtube_pipe_stream_ytdlp_exit', {
-            title: source.title,
-            url: source.url,
-            exitCode: code,
-            signal,
-          });
-        }
+            hasStderr: stderrBuf.trim().length > 0,
+          },
+        );
       } else {
         logEvent('youtube_pipe_stream_ytdlp_done', {
           title: source.title,


### PR DESCRIPTION
## Contexto

3 footguns isolados identificados pela análise de performance/arquitetura (análise-1 §7 e análise-4 A7). Cada fix toca um único arquivo sem dependências entre si — baixo risco de conflito com PRs paralelos no MusicManager.

---

## Fix 1 — Footgun do RESOLVER_URL (`.env.template`)

**Problema:** `RESOLVER_URL=http://youtube-resolver:3001` estava **descomentada** no template. Qualquer deploy que copie o template sem revisar essa linha ativa o `ResolverYouTubeService` (legado Pi-3, dormente) no lugar do `YouTubeService`. O resolver **não implementa `spawnPipeStream`** → todo playback YouTube quebra com `"spawnPipeStream not available"`, search funciona mas tocar não.

**Fix:** Linha comentada + aviso explicando por que deixar vazio (caminho ativo = YouTube direto via WARP/`YTDLP_PROXY`).

---

## Fix 2 — `fetchYouTubeMeta` indo sem proxy (`src/commands/play.ts`)

**Problema:** `fetchYouTubeMeta` (chamado quando o usuário cola uma URL do YouTube direta no `/play`) usava `spawn('yt-dlp', ['--dump-json', '--no-warnings', '--skip-download', url])` — sem `--user-agent`, sem `--proxy`. Era o único call-site que não passava pelo WARP, exposto diretamente ao IP de datacenter Oracle → provável "Sign in to confirm you're not a bot" do YouTube.

**Fix:** Substituídos os args hardcoded por `buildYtDlpBaseArgs({ includeProxy: true, includeSocketTimeout: true })`. Mesmo padrão dos outros call-sites (`spawnPipeStream`, `searchWithYtDlp`, `fetchMeta`, `getStreamUrl`).

---

## Fix 3 — Resiliência do pipe (`src/services/YouTubeService.ts`)

**Problema:** `spawnPipeStream` não tinha `--retries` nem `--fragment-retries`. Um hiccup transitório do WARP no meio do download matava a faixa sem re-tentar.

**Fix:** Adicionado `--retries 10` e `--fragment-retries 10`. Valor 10 é suficientemente alto para absorver jitter passageiro sem bloquear indefinidamente (yt-dlp usa backoff exponencial entre tentativas).

**Bônus (R6):** Exit != 0 do yt-dlp sem stderr era logado como `logEvent` (nível INFO) — invisível no `error.log`. Unificado para sempre cair em `logError` com mensagem de fallback quando stderr está vazio, acrescentando `hasStderr` para triagem. Facilita debugar faixas que morrem silenciosamente.

---

## Arquivos alterados

| Arquivo | Fix |
|---|---|
| `.env.template` | Fix 1 — comenta RESOLVER_URL |
| `src/commands/play.ts` | Fix 2 — buildYtDlpBaseArgs no fetchYouTubeMeta |
| `src/services/YouTubeService.ts` | Fix 3 — --retries/--fragment-retries + logError no exit |

`MusicManager.ts` **não tocado** (PR paralelo em andamento).

---

## Validação

- `npm run build` — verde
- `npm run typecheck` — verde (sem erros novos)
- `npm run lint` — 65 warnings pré-existentes, 0 errors, nenhum warning novo introduzido
- `npm test` — 8/8 passando

---

Built by VHXCO Agentic Software House