### PR TITLE
fix(voice): graceful reconnect, Ready gate, listener cleanup (R1/R2/R7)

### DIFF
--- a/src/services/MusicManager.ts
+++ b/src/services/MusicManager.ts
@@ -8,6 +8,7 @@ import {
   joinVoiceChannel,
   VoiceConnectionStatus,
   StreamType,
+  entersState,
 } from '@discordjs/voice';
 import { VoiceChannel } from 'discord.js';
 import { spawn, ChildProcess } from 'child_process';
@@ -60,9 +61,24 @@ export class MusicManager {
         logEvent('voice_connection_ready', { guildId, channelId: channel.id });
       });
 
-      connection.on(VoiceConnectionStatus.Disconnected, () => {
-        logEvent('voice_connection_disconnected', { guildId });
-        this.cleanup(guildId);
+      // R1 fix: graceful reconnect — VoiceConnectionStatus.Disconnected fires on
+      // routine events (region switch, ICE renegotiation, UDP jitter) that Discord
+      // recovers from automatically. Only do a full teardown on confirmed terminal
+      // disconnections.
+      connection.on(VoiceConnectionStatus.Disconnected, async () => {
+        try {
+          // Give Discord up to 5 s to move into Signalling or Connecting on its own.
+          // If either resolves, the reconnect is in progress — preserve queue/session.
+          await Promise.race([
+            entersState(connection, VoiceConnectionStatus.Signalling, 5_000),
+            entersState(connection, VoiceConnectionStatus.Connecting, 5_000),
+          ]);
+          logEvent('voice_reconnecting', { guildId });
+        } catch {
+          // Neither state was reached within 5 s → this is a terminal disconnection.
+          logWarning('voice_disconnected_terminal', { guildId });
+          this.cleanup(guildId);
+        }
       });
 
       connection.on('error', (error) => {
@@ -74,6 +90,19 @@ export class MusicManager {
         channelId: channel.id,
         channelName: channel.name,
       });
+
+      // R2 fix: wait for the connection to be Ready before returning.
+      // Without this, callers that immediately start playback hit a race where
+      // the connection is still in Signalling/Connecting and audio is never heard.
+      try {
+        await entersState(connection, VoiceConnectionStatus.Ready, 30_000);
+        logEvent('voice_ready', { guildId, channelId: channel.id });
+      } catch (err) {
+        logError('voice_ready_timeout', err as Error, { guildId, channelId: channel.id });
+        connection.destroy();
+        this.voiceConnections.delete(guildId);
+        return null;
+      }
 
       return connection;
     } catch (error) {
@@ -111,6 +140,9 @@ export class MusicManager {
     // Cleanup audio player
     const player = this.audioPlayers.get(guildId);
     if (player) {
+      // R7 fix: remove all listeners BEFORE stop so no stale event (Idle/error)
+      // fires after teardown and re-enters playback logic on a dead session.
+      player.removeAllListeners();
       player.stop(true);
       this.audioPlayers.delete(guildId);
     }
@@ -345,6 +377,12 @@ export class MusicManager {
 
         // Set up player event handlers
         player.on(AudioPlayerStatus.Playing, () => {
+          // R7 gate: if the session was torn down (e.g. reconnect failed) while
+          // a resource was being prepared, this handler fires on a dead session.
+          // Bail out silently — removeAllListeners() in cleanup normally prevents
+          // this, but an in-flight promise can race past it.
+          if (!this.voiceConnections.has(guildId)) return;
+
           const data = this.getGuildData(guildId);
           data.isPlaying = true;
           data.isPaused = false;
@@ -396,11 +434,14 @@ export class MusicManager {
         });
 
         player.on(AudioPlayerStatus.Paused, () => {
+          if (!this.voiceConnections.has(guildId)) return; // R7 gate
           guildData.isPaused = true;
           logEvent('audio_player_paused', { guildId });
         });
 
         player.on(AudioPlayerStatus.Idle, async () => {
+          if (!this.voiceConnections.has(guildId)) return; // R7 gate
+
           const data = this.getGuildData(guildId);
           data.isPlaying = false;
           data.isPaused = false;
@@ -420,6 +461,8 @@ export class MusicManager {
         });
 
         player.on('error', (error) => {
+          if (!this.voiceConnections.has(guildId)) return; // R7 gate
+
           const data = this.getGuildData(guildId);
           // Clean up active stream tracking
           if (data.currentSong) {


### PR DESCRIPTION
## O problema

**O bot travava no meio da música** — a causa raiz é que qualquer desconexão de voz (incluindo as rotineiras de região/ICE/UDP comuns em VM cloud com WARP) chamava `cleanup()` imediatamente, destruindo a sessão e **zerando a fila**. Três issues encadeadas:

### R1 — `Disconnected` → `cleanup()` direto (causa #1 do travamento)
`VoiceConnectionStatus.Disconnected` no `@discordjs/voice` dispara em eventos **recuperáveis** (troca de região, renegociação ICE, jitter UDP). O código anterior chamava `cleanup()` sempre, o que apagava a fila, parava o player e destruía a sessão em cada hiccup de rede.

### R2 — `joinVoiceChannel` sem aguardar `Ready`
A função retornava a connection "crua" sem esperar o handshake. Se o `/play` chegasse antes da connection ficar `Ready`, o áudio nunca tocava — falha silenciosa sem mensagem de erro.

### R7 — Listeners do player não removidos no `cleanup`
`player.removeAllListeners()` não era chamado antes do teardown. Qualquer evento tardio (`Idle` / `error`) de um resource em-flight disparava depois do cleanup, podendo re-entrar na lógica de playback sobre uma sessão morta.

---

## O fix (cirúrgico — sem refactor de arquitetura)

### R1 — Reconnect gracioso no `Disconnected`
```ts
connection.on(VoiceConnectionStatus.Disconnected, async () => {
  try {
    await Promise.race([
      entersState(connection, VoiceConnectionStatus.Signalling, 5_000),
      entersState(connection, VoiceConnectionStatus.Connecting, 5_000),
    ]);
    logEvent('voice_reconnecting', { guildId }); // Discord reconectando — preserva fila/sessão
  } catch {
    logWarning('voice_disconnected_terminal', { guildId }); // Só agora destrói
    this.cleanup(guildId);
  }
});
```
- Disconnect transitório (região/ICE) → **fila preservada**, bot volta a tocar sozinho
- Disconnect real (kick, 5 s sem resposta) → `cleanup()` como antes

### R2 — `entersState(Ready)` após join
```ts
await entersState(connection, VoiceConnectionStatus.Ready, 30_000);
// Se timeout: destroy + delete + return null (caller já trata null)
```
Elimina a race de "bot entrou mas nunca tocou" no primeiro `/play`.

### R7 — Cleanup de listeners
```ts
// Em cleanup():
player.removeAllListeners(); // ← antes de stop(true)
player.stop(true);
```
E guards no topo de cada handler:
```ts
player.on(AudioPlayerStatus.Playing, () => {
  if (!this.voiceConnections.has(guildId)) return; // R7 gate
  // ...
});
```

### Bônus (R6 parcial)
`voice_disconnected_terminal` promovido de `logEvent` para `logWarning` — desconexões terminais agora aparecem no grep de `warn`/`error`.

---

## Arquivos alterados
- `src/services/MusicManager.ts` — único arquivo, 46 linhas adicionadas, 3 removidas

## Smoke test pós-deploy
- [ ] `/play <url>` — bot entra, aguarda Ready, começa a tocar
- [ ] Bot aguenta reconexão transitória (verificar logs: `voice_reconnecting` sem `voice_disconnected_terminal`)
- [ ] Kick manual do bot do canal → `voice_disconnected_terminal` nos logs, bot sai limpo, fila limpa
- [ ] `/play` funciona normalmente após o kick (nova sessão)

⚠️ **Mexe em conexão de voz ativa** — recomendo `/play` logo após o deploy pra confirmar que o caminho happy path está ok antes de testar o reconnect.

---
Built by VHXCO Builder <ops@vhxco.io>