### PR TITLE
perf(audio): opus passthrough via demuxProbe — elimina transcode ffmpeg no ARM

### DIFF
--- a/src/services/MusicManager.ts
+++ b/src/services/MusicManager.ts
@@ -9,6 +9,7 @@ import {
   VoiceConnectionStatus,
   StreamType,
   entersState,
+  demuxProbe,
 } from '@discordjs/voice';
 import { VoiceChannel } from 'discord.js';
 import { spawn, ChildProcess } from 'child_process';
@@ -923,11 +924,51 @@ export class MusicManager {
       pid: ytdlpProc.pid,
     });
 
-    // @discordjs/voice StreamType.Arbitrary: voice will spawn its own ffmpeg
-    // to transcode whatever format yt-dlp emits (webm/m4a) into opus for Discord.
-    const resource = createAudioResource(ytdlpProc.stdout, {
-      inputType: StreamType.Arbitrary,
-      inlineVolume: true,
+    // 🎯 demuxProbe: inspect the first bytes of the yt-dlp stdout to detect the
+    // container/codec type.  For webm+opus (YouTube format 251, 48 kHz) it
+    // returns StreamType.WebmOpus → @discordjs/voice uses the WebmDemuxer from
+    // prism-media to extract opus packets directly — zero ffmpeg, zero re-encode.
+    // For m4a/aac or any other container it falls back to StreamType.Arbitrary →
+    // voice spawns its own ffmpeg transcoder exactly as before.
+    //
+    // IMPORTANT: demuxProbe consumes the beginning of the stream; we MUST use the
+    // `stream` it returns (not ytdlpProc.stdout directly) in createAudioResource.
+    //
+    // inlineVolume: false — passthrough opus packets cannot have a PCM VolumeTransformer
+    // inserted without re-encoding.  The /volume command only updates guildData.volume
+    // and logs (does NOT apply in real-time), so this is a no-op loss functionally.
+    let probeStream: import('stream').Readable;
+    let detectedType: StreamType;
+
+    try {
+      const probeResult = await demuxProbe(ytdlpProc.stdout);
+      probeStream = probeResult.stream;
+      detectedType = probeResult.type;
+    } catch (probeError) {
+      // demuxProbe can reject if yt-dlp emitted nothing (empty stream / early exit).
+      // Kill the orphaned yt-dlp process and surface the error to the caller so
+      // MusicManager can attempt the next song gracefully.
+      this.killActiveYtdlpProcess(guildId, 'demux_probe_error');
+      throw probeError;
+    }
+
+    logEvent('youtube_pipe_audio_resource_type', {
+      guildId,
+      title: song.title,
+      pid: ytdlpProc.pid,
+      // WebmOpus → passthrough (no ffmpeg), Arbitrary → ffmpeg transcode fallback
+      streamType: detectedType,
+      passthrough: detectedType === StreamType.WebmOpus,
+    });
+
+    const resource = createAudioResource(probeStream, {
+      inputType: detectedType,
+      // inlineVolume MUST be false for opus passthrough: inserting a PCM
+      // VolumeTransformer would force a full opus→PCM→opus round-trip, defeating
+      // the entire purpose of the passthrough path.  The /volume command is a
+      // best-effort log-only operation today (no real-time apply), so there is
+      // no functional regression from disabling it here.
+      inlineVolume: false,
       metadata: { title: song.title },
     });
 

--- a/src/services/YouTubeService.ts
+++ b/src/services/YouTubeService.ts
@@ -294,8 +294,12 @@ export class YouTubeService extends BaseMusicService {
       url: source.url,
     });
 
-    // Best-audio formats, prefer webm (opus-native) then m4a, then anything
-    const format = 'bestaudio[ext=webm]/bestaudio[ext=m4a]/bestaudio';
+    // Best-audio formats — prefer webm+opus explicitly (passthrough-friendly):
+    //   1. webm container with opus codec (YouTube format 251, 48 kHz — zero transcode)
+    //   2. any webm (could still be opus, demuxProbe will detect)
+    //   3. m4a (AAC — will fall back to ffmpeg transcode in voice layer)
+    //   4. anything else (worst case)
+    const format = 'bestaudio[acodec=opus]/bestaudio[ext=webm]/bestaudio[ext=m4a]/bestaudio';
 
     // UA + socket-timeout + proxy (WARP) from shared util
     const ytDlpArgs: string[] = [


### PR DESCRIPTION
## O que muda

O path de playback YouTube (`createYouTubePipeResource`) hoje usa `StreamType.Arbitrary` + `inlineVolume: true` — o `@discordjs/voice` spawna um **processo ffmpeg interno** que decodifica o webm/m4a do yt-dlp e re-encoda em opus para o Discord. O webm padrão do YouTube (format 251) **já é opus 48 kHz** — o mesmo codec que o Discord quer. Estávamos fazendo opus→PCM→opus, no ARM, que é o processo mais caro do playback.

### Abordagem: `demuxProbe` com fallback automático

Em vez de hardcodar o tipo, usamos `demuxProbe` (do próprio `@discordjs/voice`, usa prism-media 1.3.5 já instalado):

1. `demuxProbe(ytdlpProc.stdout)` lê o início do stream e detecta o container.
2. **WebmOpus** (caminho feliz) → `@discordjs/voice` usa o `WebmDemuxer` do prism-media para extrair pacotes opus e mandá-los direto ao Discord. **Zero ffmpeg, zero decode, zero re-encode.**
3. **Arbitrary** (fallback m4a/aac ou qualquer outro) → ffmpeg interno do voice transcoda normalmente, idêntico ao comportamento anterior.
4. O log `youtube_pipe_audio_resource_type` emite `streamType` e `passthrough: bool` para confirmar o path tomado no smoke test.

O `stream` retornado pelo probe é usado no `createAudioResource` (não o `stdout` cru — probe consome os primeiros bytes e o resultado deve ser usado no lugar do original).

### Formato do yt-dlp atualizado

`bestaudio[acodec=opus]/bestaudio[ext=webm]/bestaudio[ext=m4a]/bestaudio`

Filtra por `acodec=opus` antes de qualquer webm genérico — vídeos antigos com webm+Vorbis não quebrariam o demuxer de opus, mas o fallback Arbitrary cobre esse caso de qualquer forma.

### `inlineVolume: false`

O passthrough opus não pode ter `VolumeTransformer` (opera sobre PCM) sem re-encodar — o que anularia todo o ganho de CPU. O `/volume` hoje só atualiza `guildData.volume` e loga, **sem aplicar em tempo real** (`setVolume` em `MusicManager.ts:590-598`). A linha `resource.volume?.setVolume(...)` no `playAudio` usa `?.` que já protege silenciosamente. Sem regressão funcional.

## Arquivos modificados

- `src/services/MusicManager.ts`: import `demuxProbe`; substitui `Arbitrary`/`inlineVolume:true` por `await demuxProbe` → `{stream, type}`; log do tipo detectado; trata erro do probe com kill do processo antes de re-throw.
- `src/services/YouTubeService.ts`: formato de pipe atualizado para priorizar `acodec=opus`.

## Resultados de build/test

```
npm run build  — 0 erros TypeScript
npm run lint   — 0 errors (65 warnings pré-existentes de any, nenhum novo)
npm test       — 8/8 testes passando
```

## Smoke test pós-deploy

Após deploy, rodar `/play <qualquer música do YouTube>` e confirmar nos logs:

```json
{ "event": "youtube_pipe_audio_resource_type", "streamType": "webm/opus", "passthrough": true }
```

Se `passthrough: false` aparecer, o yt-dlp caiu para m4a/fallback — ainda funciona, mas sem o ganho de CPU. Para medir o impacto: `docker stats` durante uma faixa de 4 min. Esperado: sem processo `ffmpeg` no `ps aux` dentro do container durante playback YouTube.

⚠️ **NÃO mergeie sem smoke test** — código de playback vivo.

---
🏗 Built by VHXCO Agentic Software House