### PR TITLE
fix(status): versioned state + stale-guard + pause/resume embed + real counter [PR1]

### DIFF
--- a/src/services/Announcer.ts
+++ b/src/services/Announcer.ts
@@ -17,6 +17,21 @@ class AnnouncerImpl {
   private client: Client | null = null;
   private lastNowPlayingMessageIdByGuild = new Map<string, string>();
 
+  /**
+   * Stale-guard: tracks the last version number that was successfully drawn
+   * for each guild. A flush with version <= this value is discarded because a
+   * newer edit already landed (or is in flight and will land).
+   */
+  private renderedVersionByGuild = new Map<string, number>();
+
+  /**
+   * Mutex: tracks guilds whose flush is currently in flight. While flushing,
+   * any additional concurrent call returns immediately — the in-flight flush
+   * will re-check versions at the end and kick off another round if needed.
+   * (We intentionally do NOT queue — the last caller always wins.)
+   */
+  private flushingByGuild = new Set<string>();
+
   setClient(client: Client) {
     this.client = client;
   }
@@ -31,8 +46,46 @@ class AnnouncerImpl {
       startedAt?: number; // epoch ms
       recent?: QueuedSong[];
       lastShuffle?: { by: string; at: number };
+      isPaused?: boolean;
+      /** State version from GuildMusicData — used for stale-guard. */
+      version?: number;
+      /** Real total tracks played this session (not capped at 6). */
+      playedCount?: number;
     },
   ) {
+    // ── Stale-guard ──────────────────────────────────────────────────────────
+    // If the caller provided a version number and a newer (or equal) one has
+    // already been drawn, this snapshot is stale — discard immediately.
+    const incomingVersion = data.version ?? -1;
+    if (incomingVersion >= 0) {
+      const rendered = this.renderedVersionByGuild.get(guildId) ?? -1;
+      if (incomingVersion <= rendered) {
+        logEvent('status_flush_discarded_stale', { guildId, incomingVersion, rendered });
+        return;
+      }
+    }
+
+    // ── Mutex ─────────────────────────────────────────────────────────────────
+    // If another flush is already in flight for this guild, return — the
+    // in-flight flush will handle it when it checks renderedVersion at the end.
+    if (this.flushingByGuild.has(guildId)) {
+      logEvent('status_flush_skipped_mutex', { guildId, incomingVersion });
+      return;
+    }
+
+    this.flushingByGuild.add(guildId);
+    try {
+      await this._doFlush(guildId, data, incomingVersion);
+    } finally {
+      this.flushingByGuild.delete(guildId);
+    }
+  }
+
+  private async _doFlush(
+    guildId: string,
+    data: Parameters<AnnouncerImpl['updateGuildStatus']>[1],
+    incomingVersion: number,
+  ): Promise<void> {
     try {
       if (!this.client) return;
       const channelId = botConfig.musaChannelId;
@@ -41,6 +94,17 @@ class AnnouncerImpl {
       const channel = await this.client.channels.fetch(channelId);
       if (!channel || !channel.isTextBased()) return;
       const textChannel = channel as TextChannel;
+
+      // Re-check the stale-guard AFTER the async channel.fetch above — a
+      // higher-version flush that started before we fetched the channel may
+      // have already committed while we awaited.
+      if (incomingVersion >= 0) {
+        const rendered = this.renderedVersionByGuild.get(guildId) ?? -1;
+        if (incomingVersion <= rendered) {
+          logEvent('status_flush_discarded_stale_post_fetch', { guildId, incomingVersion, rendered });
+          return;
+        }
+      }
 
       // Resolve voice channel name if only id was provided
       if (!data.voiceChannelName && data.voiceChannelId) {
@@ -65,14 +129,17 @@ class AnnouncerImpl {
           } else {
             await msg.edit({ embeds: [embed] });
           }
-          logEvent('status_message_edited', { guildId, messageId: lastId });
+          logEvent('status_message_edited', { guildId, messageId: lastId, version: incomingVersion });
+          // Mark this version as drawn
+          if (incomingVersion >= 0) this.renderedVersionByGuild.set(guildId, incomingVersion);
           return;
         } catch {
-          // fallthrough to send
+          // fallthrough to send/recover
         }
       }
 
-      // Try to reuse an existing bot message in this channel (after restarts), paginating up to ~1000 msgs
+      // Try to reuse an existing bot message in this channel (after restarts),
+      // paginating up to ~1000 msgs.
       try {
         const botId = this.client.user?.id;
         let before: string | undefined = undefined;
@@ -93,7 +160,13 @@ class AnnouncerImpl {
             if (files) await existing.edit({ embeds: [embed], files });
             else await existing.edit({ embeds: [embed] });
             this.lastNowPlayingMessageIdByGuild.set(guildId, existing.id);
-            logEvent('status_message_reused', { guildId, messageId: existing.id, page: i });
+            logEvent('status_message_reused', {
+              guildId,
+              messageId: existing.id,
+              page: i,
+              version: incomingVersion,
+            });
+            if (incomingVersion >= 0) this.renderedVersionByGuild.set(guildId, incomingVersion);
             return;
           }
           const oldest = list[list.length - 1];
@@ -106,7 +179,8 @@ class AnnouncerImpl {
 
       const sent = await textChannel.send(files ? { embeds: [embed], files } : { embeds: [embed] });
       this.lastNowPlayingMessageIdByGuild.set(guildId, sent.id);
-      logEvent('status_message_sent', { guildId, messageId: sent.id });
+      logEvent('status_message_sent', { guildId, messageId: sent.id, version: incomingVersion });
+      if (incomingVersion >= 0) this.renderedVersionByGuild.set(guildId, incomingVersion);
     } catch (error) {
       logError('update_guild_status_failed', error as Error, { guildId });
     }
@@ -119,14 +193,34 @@ class AnnouncerImpl {
     startedAt?: number;
     recent?: QueuedSong[];
     lastShuffle?: { by: string; at: number };
+    isPaused?: boolean;
+    playedCount?: number;
   }): Promise<EmbedBuilder> {
     const fields: { name: string; value: string; inline?: boolean }[] = [];
+    const isPaused = data.isPaused ?? false;
+
+    // Determine title and color based on play state
+    let title: string;
+    let color: string;
+    if (!data.currentSong) {
+      title = 'Silêncio Encantado';
+      color = MusaColors.warning as string;
+    } else if (isPaused) {
+      title = `${MusaEmojis.pause} Pausada`;
+      color = MusaColors.queue as string; // visually distinct from "playing"
+    } else {
+      title = 'Tocando Agora';
+      color = MusaColors.nowPlaying as string;
+    }
+
     const base: any = {
-      title: data.currentSong ? 'Tocando Agora' : 'Silêncio Encantado',
+      title,
       description: data.currentSong
-        ? getRandomPhrase('playing') || `${MusaEmojis.notes} Tocando com carinho!`
+        ? isPaused
+          ? `${MusaEmojis.pause} Em pausa...`
+          : getRandomPhrase('playing') || `${MusaEmojis.notes} Tocando com carinho!`
         : getRandomPhrase('idle') || `${MusaEmojis.mute || '🔇'} Em silêncio...`,
-      color: data.currentSong ? MusaColors.nowPlaying : MusaColors.warning,
+      color,
       fields,
       timestamp: true,
     };
@@ -224,7 +318,10 @@ class AnnouncerImpl {
     }
 
     const embed = createMusaEmbed(base);
+
     // Recently played block (optional)
+    // The list is capped at 6 for display, but the counter uses playedCount
+    // (the real total) so it keeps growing past 6.
     const recent = (data.recent || []).slice(0, 6);
     if (recent.length > 0) {
       const linesRecent = recent.map((q, idx) => {
@@ -232,14 +329,93 @@ class AnnouncerImpl {
         const by = q.requestedBy ? ` • por ${truncateText(q.requestedBy, 20)}` : '';
         return `${idx + 1}. ${truncateText(q.title, 60)}${artist}${by}`;
       });
+      // Use playedCount (real total) for the number in the label; fall back to
+      // recent.length when the field is absent (old callers / tests).
+      const count =
+        typeof data.playedCount === 'number' && data.playedCount > 0 ? data.playedCount : recent.length;
       embed.addFields({
-        name: `${MusaEmojis.cd} Já Tocaram (${recent.length})`,
+        name: `${MusaEmojis.cd} Já Tocaram (${count})`,
         value: linesRecent.join('\n'),
         inline: false,
       });
     }
     if (files) (embed as any).__files = files;
     return embed;
+  }
+
+  // announceNowPlaying kept for any callers that may still use it (commands etc.)
+  async announceNowPlaying(guildId: string, song: QueuedSong, voiceChannelId?: string, thumbnail?: string) {
+    try {
+      if (!this.client) return;
+      const channelId = botConfig.musaChannelId;
+      if (!channelId) return;
+
+      const channel = await this.client.channels.fetch(channelId);
+      if (!channel || !channel.isTextBased()) return;
+      const textChannel = channel as TextChannel;
+
+      // Resolve voice channel name if possible
+      let voiceName = '';
+      if (voiceChannelId) {
+        try {
+          const vc = await this.client.channels.fetch(voiceChannelId);
+          if (vc && 'name' in vc) voiceName = (vc as any).name as string;
+        } catch {
+          /* ignore */
+        }
+      }
+
+      const description = getRandomPhrase('playing') || `${MusaEmojis.notes} Tocando com carinho!`;
+      const base: any = {
+        title: 'Tocando Agora',
+        description,
+        color: MusaColors.nowPlaying,
+        fields: [
+          { name: `${MusaEmojis.notes} Música`, value: truncateText(song.title, 70), inline: false },
+          ...(voiceName
+            ? [{ name: `${MusaEmojis.microphone} Canal de Voz`, value: voiceName, inline: true }]
+            : []),
+        ],
+        timestamp: true,
+      };
+      const thumb = thumbnail || ((song as any).thumbnail as string | undefined);
+
+      // Prepare optional attachment for fallback thumbnail (musa.png)
+      let files: Array<{ attachment: string; name?: string }> | undefined;
+      if (thumb) {
+        base.thumbnail = thumb;
+      } else {
+        const fallbackPath = path.resolve(process.cwd(), 'musa.png');
+        if (fs.existsSync(fallbackPath)) {
+          base.thumbnail = 'attachment://musa.png';
+          files = [{ attachment: fallbackPath, name: 'musa.png' }];
+        }
+      }
+      const embed: EmbedBuilder = createMusaEmbed(base);
+
+      // Edit previous now-playing message if exists
+      const lastId = this.lastNowPlayingMessageIdByGuild.get(guildId);
+      if (lastId) {
+        try {
+          const msg = await textChannel.messages.fetch(lastId);
+          if (files) {
+            await msg.edit({ embeds: [embed], files });
+          } else {
+            await msg.edit({ embeds: [embed] });
+          }
+          logEvent('now_playing_edited', { guildId, messageId: lastId });
+          return;
+        } catch {
+          // If fetch/edit fails, fall back to sending a new message
+        }
+      }
+
+      const sent = await textChannel.send(files ? { embeds: [embed], files } : { embeds: [embed] });
+      this.lastNowPlayingMessageIdByGuild.set(guildId, sent.id);
+      logEvent('now_playing_sent', { guildId, messageId: sent.id });
+    } catch (error) {
+      logError('announce_now_playing_failed', error as Error, { guildId, title: song.title });
+    }
   }
 }
 

--- a/src/services/MusicManager.ts
+++ b/src/services/MusicManager.ts
@@ -215,8 +215,8 @@ export class MusicManager {
     // Schedule prefetch for upcoming songs
     this.schedulePrefetch(guildId);
 
-    // Update status message (queue changed)
-    this.pushStatus(guildId);
+    // Update status message (queue changed) — version bump
+    this.bumpAndPushStatus(guildId);
 
     // Start playing if nothing is currently playing
     if (!guildData.isPlaying && !guildData.currentSong) {
@@ -268,8 +268,8 @@ export class MusicManager {
     // Schedule a single prefetch pass
     this.schedulePrefetch(guildId);
 
-    // Update status message once
-    this.pushStatus(guildId);
+    // Update status message once — version bump
+    this.bumpAndPushStatus(guildId);
 
     // Start playing if nothing is currently playing
     if (!guildData.isPlaying && !guildData.currentSong) {
@@ -324,9 +324,10 @@ export class MusicManager {
         /* ignore */
       }
 
-      // Update status message to reflect silence/empty queue
-      // Update status (currentSong already null above)
-      this.pushStatus(guildId);
+      // Update status message to reflect silence/empty queue — version bump
+      // Reset playedCount when going truly idle (no next song)
+      guildData.playedCount = 0;
+      this.bumpAndPushStatus(guildId);
       logEvent('queue_finished', { guildId });
       return;
     }
@@ -410,10 +411,12 @@ export class MusicManager {
             /* ignore */
           }
 
-          // Announce in the Musa channel with embed and optional thumbnail
-          this.pushStatus(guildId);
+          // Announce in the Musa channel with embed and optional thumbnail — version bump
+          this.bumpAndPushStatus(guildId);
 
-          // If current song lacks thumbnail, fetch lightweight metadata and update status
+          // If current song lacks thumbnail, fetch lightweight metadata and update status.
+          // Thumbnail fill does NOT bump the version: it is a cosmetic refinement of the
+          // same "now playing" state that was already versioned above.
           try {
             if (current && current.service === 'youtube' && !current.thumbnail) {
               const yt = this.multiSourceManager.getService('youtube') as any;
@@ -423,6 +426,7 @@ export class MusicManager {
                   .then((meta: any) => {
                     if (meta?.thumbnail && data.currentSong && data.currentSong.url === current.url) {
                       (data.currentSong as any).thumbnail = meta.thumbnail;
+                      // No version bump — same logical state, just filled the thumbnail
                       this.pushStatus(guildId);
                     }
                   })
@@ -451,7 +455,10 @@ export class MusicManager {
           if (data.currentSong) {
             data.recentlyPlayed = data.recentlyPlayed || [];
             data.recentlyPlayed.unshift(data.currentSong);
+            // Keep the list capped at 6 items (display limit), but increment the
+            // real playedCount counter so the embed can show the true total.
             if (data.recentlyPlayed.length > 6) data.recentlyPlayed = data.recentlyPlayed.slice(0, 6);
+            data.playedCount = (data.playedCount ?? 0) + 1;
             this.activeStreams.delete(data.currentSong.url);
           }
 
@@ -523,7 +530,14 @@ export class MusicManager {
     const player = this.audioPlayers.get(guildId);
     if (player && player.state.status === AudioPlayerStatus.Playing) {
       player.pause();
+      // Update isPaused eagerly so the snapshot in pushStatus is correct.
+      // (The AudioPlayerStatus.Paused event also sets this, but it fires async
+      // after the Discord edit — setting it here avoids the race.)
+      const data = this.getGuildData(guildId);
+      data.isPaused = true;
       logEvent('music_paused', { guildId });
+      // Bump version so the Announcer discards any in-flight "playing" edit
+      this.bumpAndPushStatus(guildId);
       return true;
     }
     return false;
@@ -533,7 +547,12 @@ export class MusicManager {
     const player = this.audioPlayers.get(guildId);
     if (player && player.state.status === AudioPlayerStatus.Paused) {
       player.unpause();
+      // Update isPaused eagerly (symmetric with pause above).
+      const data = this.getGuildData(guildId);
+      data.isPaused = false;
       logEvent('music_resumed', { guildId });
+      // Bump version so the Announcer discards any in-flight "paused" edit
+      this.bumpAndPushStatus(guildId);
       return true;
     }
     return false;
@@ -565,6 +584,7 @@ export class MusicManager {
     delete guildData.currentSongStartedAt;
     guildData.isPlaying = false;
     guildData.isPaused = false;
+    guildData.playedCount = 0;
 
     logEvent('music_stopped', { guildId });
     try {
@@ -573,19 +593,25 @@ export class MusicManager {
       /* ignore */
     }
 
-    // Reflect stopped state in status message
-    this.pushStatus(guildId);
+    // Reflect stopped state in status message — version bump
+    this.bumpAndPushStatus(guildId);
   }
 
-  skip(guildId: string): void {
+  skip(guildId: string, by?: string, byId?: string): void {
     // Kill yt-dlp pipe process first so the old download doesn't keep running
     this.killActiveYtdlpProcess(guildId, 'skip');
+
+    // Record who skipped for display in the status embed (mirrors lastShuffle pattern)
+    if (by) {
+      const data = this.getGuildData(guildId);
+      (data as any).lastSkip = { by, ...(byId ? { byId } : {}), at: Date.now() };
+    }
 
     const player = this.audioPlayers.get(guildId);
     if (player) {
       player.stop(); // This will trigger the 'idle' event and play next song
     }
-    logEvent('song_skipped', { guildId });
+    logEvent('song_skipped', { guildId, by: by ?? 'unknown' });
   }
 
   setVolume(guildId: string, volume: number): void {
@@ -633,8 +659,8 @@ export class MusicManager {
     // Re-evaluate prefetch targets after shuffle
     this.schedulePrefetch(guildId, 250);
 
-    // Update status message after shuffle
-    this.pushStatus(guildId);
+    // Update status message after shuffle — version bump
+    this.bumpAndPushStatus(guildId);
   }
 
   // Restore queue to the original insertion order (by stable queueId)
@@ -658,8 +684,8 @@ export class MusicManager {
     // Re-evaluate prefetch targets after order change
     this.schedulePrefetch(guildId, 250);
 
-    // Update status message after order change
-    this.pushStatus(guildId);
+    // Update status message after order change — version bump
+    this.bumpAndPushStatus(guildId);
   }
 
   clearQueue(guildId: string): void {
@@ -670,23 +696,31 @@ export class MusicManager {
 
     logEvent('queue_cleared', { guildId, removedCount });
 
-    // Reflect cleared queue in status message
-    this.pushStatus(guildId);
+    // Reflect cleared queue in status message — version bump
+    this.bumpAndPushStatus(guildId);
   }
 
   /**
    * Fire-and-forget Announcer status update for a guild.
-   * Builds the standard payload from guild data + voice connection and swallows errors
-   * (status updates are cosmetic — they must never crash the playback path).
+   * Builds an IMMUTABLE snapshot (queue is sliced, not the live reference) to
+   * prevent the render from seeing a later mutation if the Announcer awaits I/O
+   * before consuming the payload.  Also passes the current version so the
+   * Announcer can discard stale (out-of-order) async edits.
+   * Status updates are cosmetic — they must never crash the playback path.
    */
   private pushStatus(guildId: string): void {
     try {
       const guildData = this.getGuildData(guildId);
       const connection = this.voiceConnections.get(guildId);
+      // Take a copy of the queue at this moment — the live array may be mutated
+      // (shift/push) while the async render is still in flight.
       const payload: any = {
         currentSong: guildData.currentSong,
-        queue: guildData.queue,
-        recent: guildData.recentlyPlayed,
+        queue: guildData.queue.slice(), // snapshot, not live reference
+        recent: guildData.recentlyPlayed ? guildData.recentlyPlayed.slice() : [],
+        isPaused: guildData.isPaused,
+        version: guildData.version ?? 0,
+        playedCount: guildData.playedCount ?? 0,
       };
       const voiceChannelId = connection?.joinConfig?.channelId;
       if (voiceChannelId) payload.voiceChannelId = voiceChannelId;
@@ -771,10 +805,23 @@ export class MusicManager {
         loopMode: 'off',
         nextQueueId: 1,
         shuffleEnabled: false,
+        version: 0,
+        playedCount: 0,
       };
       this.guildData.set(guildId, guildData);
     }
     return guildData;
+  }
+
+  /**
+   * Increment the state version for the guild and fire a status update.
+   * Every mutator that changes what the status embed shows must call this
+   * instead of pushStatus directly, so the version stays in sync.
+   */
+  private bumpAndPushStatus(guildId: string): void {
+    const g = this.getGuildData(guildId);
+    g.version = (g.version ?? 0) + 1;
+    this.pushStatus(guildId);
   }
 
   private startInactivityTimer(guildId: string): void {

--- a/src/types/music.ts
+++ b/src/types/music.ts
@@ -31,6 +31,12 @@ export interface GuildMusicData {
   shuffleEnabled?: boolean; // current play order mode
   inactivityTimer?: ReturnType<typeof setTimeout>;
   emptyChannelTimer?: ReturnType<typeof setTimeout>;
+  // State versioning — incremented by every mutator that affects what the
+  // status embed shows. Used by Announcer to discard stale (out-of-order)
+  // async edits. Starts at 0 when the guild record is first created.
+  version: number;
+  // Total tracks played in this session; reset on stop/truly-idle.
+  playedCount?: number;
 }
 
 export type ServiceType = 'youtube' | 'internet_archive' | 'radio' | 'spotify';

--- a/tests/statusStateVersioned.test.js
+++ b/tests/statusStateVersioned.test.js
@@ -1,0 +1,371 @@
+/**
+ * Tests for PR1 — fix/status-state-versioned
+ *
+ * Covers:
+ *  - GuildMusicData.version is initialised to 0
+ *  - version increments on every mutator that changes the embed
+ *  - pause / resume eagerly set isPaused + bump version
+ *  - playedCount increments in the Idle handler and resets on stop
+ *  - Announcer stale-guard discards calls with version <= already-drawn
+ */
+
+// ── mock @discordjs/voice (same as musicManager.test.js) ──────────────────
+jest.mock('@discordjs/voice', () => {
+  const AudioPlayerStatus = {
+    Idle: 'idle',
+    Buffering: 'buffering',
+    Paused: 'paused',
+    Playing: 'playing',
+    AutoPaused: 'autopaused',
+  };
+
+  const VoiceConnectionStatus = {
+    Connecting: 'connecting',
+    Destroyed: 'destroyed',
+    Disconnected: 'disconnected',
+    Ready: 'ready',
+    Signalling: 'signalling',
+  };
+
+  const StreamType = {
+    Arbitrary: 'arbitrary',
+    OggOpus: 'ogg/opus',
+    WebmOpus: 'webm/opus',
+    Raw: 'raw',
+    OggVorbis: 'ogg/vorbis',
+  };
+
+  const mockPlayer = {
+    on: jest.fn().mockReturnThis(),
+    play: jest.fn(),
+    stop: jest.fn(),
+    pause: jest.fn(),
+    unpause: jest.fn(),
+    state: { status: AudioPlayerStatus.Idle },
+  };
+
+  const mockConnection = {
+    on: jest.fn().mockReturnThis(),
+    subscribe: jest.fn(() => ({ unsubscribe: jest.fn() })),
+    destroy: jest.fn(),
+    joinConfig: { channelId: 'vc-1' },
+    state: { status: VoiceConnectionStatus.Ready },
+  };
+
+  return {
+    AudioPlayerStatus,
+    VoiceConnectionStatus,
+    StreamType,
+    createAudioPlayer: jest.fn(() => mockPlayer),
+    createAudioResource: jest.fn((input, opts) => ({ playStream: input, metadata: opts?.metadata })),
+    joinVoiceChannel: jest.fn(() => mockConnection),
+    entersState: jest.fn(() => Promise.resolve(mockConnection)),
+    getVoiceConnection: jest.fn(() => undefined),
+    NoSubscriberBehavior: { Pause: 'pause', Play: 'play', Stop: 'stop' },
+    demuxProbe: jest.fn(async (stream) => ({ stream, type: 'arbitrary' })),
+  };
+});
+
+// ── helpers ───────────────────────────────────────────────────────────────
+const { MusicManager } = require('../dist/services/MusicManager');
+
+function makeSong(title = 'Test Song', url = 'https://youtu.be/test') {
+  return {
+    title,
+    url,
+    service: 'youtube',
+    requestedBy: 'tester',
+    addedAt: new Date(),
+  };
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+describe('GuildMusicData.version — initialisation', () => {
+  test('new guild data starts with version = 0', () => {
+    const mm = new MusicManager();
+    const data = mm.getGuildMusicData('g-init');
+    expect(data.version).toBe(0);
+  });
+
+  test('playedCount initialises to 0', () => {
+    const mm = new MusicManager();
+    const data = mm.getGuildMusicData('g-pc');
+    expect(data.playedCount).toBe(0);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────
+describe('version bumps on mutators', () => {
+  // Each mutator that changes what the embed shows must call bumpAndPushStatus.
+  // We verify by checking that version is > 0 after each operation.
+  // (Announcer is fire-and-forget so we don't need to spy on it here.)
+
+  test('shuffleQueue bumps version', () => {
+    const mm = new MusicManager();
+    const gid = 'g-shuffle';
+    const data = mm.getGuildMusicData(gid);
+    data.queue = [makeSong('a'), makeSong('b'), makeSong('c')];
+    const before = data.version;
+    mm.shuffleQueue(gid, 'tester');
+    expect(data.version).toBeGreaterThan(before);
+  });
+
+  test('restoreOriginalOrder bumps version', () => {
+    const mm = new MusicManager();
+    const gid = 'g-restore';
+    const data = mm.getGuildMusicData(gid);
+    data.queue = [makeSong('a'), makeSong('b')];
+    const before = data.version;
+    mm.restoreOriginalOrder(gid);
+    expect(data.version).toBeGreaterThan(before);
+  });
+
+  test('clearQueue bumps version', () => {
+    const mm = new MusicManager();
+    const gid = 'g-clear';
+    const data = mm.getGuildMusicData(gid);
+    data.queue = [makeSong('x')];
+    const before = data.version;
+    mm.clearQueue(gid);
+    expect(data.version).toBeGreaterThan(before);
+    expect(data.queue).toHaveLength(0);
+  });
+
+  test('stop bumps version and resets playedCount', () => {
+    const mm = new MusicManager();
+    const gid = 'g-stop';
+    const data = mm.getGuildMusicData(gid);
+    data.playedCount = 5;
+    data.queue = [makeSong('x')];
+    const before = data.version;
+    mm.stop(gid);
+    expect(data.version).toBeGreaterThan(before);
+    expect(data.playedCount).toBe(0);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────
+describe('pause and resume — isPaused + version', () => {
+  test('pause() sets isPaused=true and bumps version when player is Playing', () => {
+    const { AudioPlayerStatus, createAudioPlayer } = require('@discordjs/voice');
+    const mockPlayer = createAudioPlayer();
+    mockPlayer.state = { status: AudioPlayerStatus.Playing };
+
+    const mm = new MusicManager();
+    const gid = 'g-pause';
+    // Inject mock player directly into the private map via getGuildMusicData
+    // side-effect: creates guild data. Then set the player.
+    mm.getGuildMusicData(gid);
+    // Access private audioPlayers via a workaround — cast to any
+    mm['audioPlayers'].set(gid, mockPlayer);
+
+    const data = mm.getGuildMusicData(gid);
+    expect(data.isPaused).toBe(false);
+    const vBefore = data.version;
+
+    const result = mm.pause(gid);
+    expect(result).toBe(true);
+    expect(data.isPaused).toBe(true);
+    expect(data.version).toBeGreaterThan(vBefore);
+  });
+
+  test('pause() returns false and does NOT bump version when already paused/idle', () => {
+    const { AudioPlayerStatus, createAudioPlayer } = require('@discordjs/voice');
+    const mockPlayer = createAudioPlayer();
+    mockPlayer.state = { status: AudioPlayerStatus.Idle };
+
+    const mm = new MusicManager();
+    const gid = 'g-pause-noop';
+    mm.getGuildMusicData(gid);
+    mm['audioPlayers'].set(gid, mockPlayer);
+
+    const data = mm.getGuildMusicData(gid);
+    const vBefore = data.version;
+
+    const result = mm.pause(gid);
+    expect(result).toBe(false);
+    // version must NOT have changed — no state mutation occurred
+    expect(data.version).toBe(vBefore);
+  });
+
+  test('resume() sets isPaused=false and bumps version when player is Paused', () => {
+    const { AudioPlayerStatus, createAudioPlayer } = require('@discordjs/voice');
+    const mockPlayer = createAudioPlayer();
+    mockPlayer.state = { status: AudioPlayerStatus.Paused };
+
+    const mm = new MusicManager();
+    const gid = 'g-resume';
+    mm.getGuildMusicData(gid);
+    mm['audioPlayers'].set(gid, mockPlayer);
+
+    const data = mm.getGuildMusicData(gid);
+    data.isPaused = true; // simulate paused state
+    const vBefore = data.version;
+
+    const result = mm.resume(gid);
+    expect(result).toBe(true);
+    expect(data.isPaused).toBe(false);
+    expect(data.version).toBeGreaterThan(vBefore);
+  });
+
+  test('resume() returns false and does NOT bump version when not paused', () => {
+    const { AudioPlayerStatus, createAudioPlayer } = require('@discordjs/voice');
+    const mockPlayer = createAudioPlayer();
+    mockPlayer.state = { status: AudioPlayerStatus.Playing };
+
+    const mm = new MusicManager();
+    const gid = 'g-resume-noop';
+    mm.getGuildMusicData(gid);
+    mm['audioPlayers'].set(gid, mockPlayer);
+
+    const data = mm.getGuildMusicData(gid);
+    const vBefore = data.version;
+
+    const result = mm.resume(gid);
+    expect(result).toBe(false);
+    expect(data.version).toBe(vBefore);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────
+describe('playedCount counter', () => {
+  test('playedCount starts at 0 and is not negative', () => {
+    const mm = new MusicManager();
+    const data = mm.getGuildMusicData('g-count');
+    expect(data.playedCount).toBe(0);
+  });
+
+  test('stop() resets playedCount to 0', () => {
+    const mm = new MusicManager();
+    const gid = 'g-count-stop';
+    const data = mm.getGuildMusicData(gid);
+    data.playedCount = 10;
+    mm.stop(gid);
+    expect(data.playedCount).toBe(0);
+  });
+
+  test('manual increment simulates Idle handler counting beyond 6', () => {
+    // The Idle handler in playAudio does: data.playedCount = (data.playedCount ?? 0) + 1
+    // and keeps recentlyPlayed capped at 6.
+    // Simulate 8 songs finishing:
+    const mm = new MusicManager();
+    const gid = 'g-count-many';
+    const data = mm.getGuildMusicData(gid);
+    data.recentlyPlayed = [];
+
+    for (let i = 0; i < 8; i++) {
+      const song = makeSong(`song-${i}`, `https://youtu.be/${i}`);
+      data.recentlyPlayed.unshift(song);
+      if (data.recentlyPlayed.length > 6) data.recentlyPlayed = data.recentlyPlayed.slice(0, 6);
+      data.playedCount = (data.playedCount ?? 0) + 1;
+    }
+
+    // recentlyPlayed must be capped at 6
+    expect(data.recentlyPlayed).toHaveLength(6);
+    // but playedCount must reflect the real total
+    expect(data.playedCount).toBe(8);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────
+describe('Announcer stale-guard (version-based discard)', () => {
+  // We import the compiled Announcer and wire a mock client so it exercises
+  // the stale-guard path without hitting Discord.
+  let Announcer;
+
+  beforeEach(() => {
+    // Clear module cache so each test gets a fresh Announcer singleton
+    jest.resetModules();
+    // Re-mock @discordjs/voice after resetModules
+    jest.mock('@discordjs/voice', () => {
+      const AudioPlayerStatus = { Idle: 'idle', Playing: 'playing', Paused: 'paused' };
+      const VoiceConnectionStatus = { Ready: 'ready', Disconnected: 'disconnected' };
+      return {
+        AudioPlayerStatus,
+        VoiceConnectionStatus,
+        StreamType: {},
+        createAudioPlayer: jest.fn(() => ({
+          on: jest.fn().mockReturnThis(),
+          play: jest.fn(),
+          stop: jest.fn(),
+          state: { status: AudioPlayerStatus.Idle },
+        })),
+        createAudioResource: jest.fn(),
+        joinVoiceChannel: jest.fn(),
+        entersState: jest.fn(),
+        demuxProbe: jest.fn(async (s) => ({ stream: s, type: 'arbitrary' })),
+      };
+    });
+    ({ Announcer } = require('../dist/services/Announcer'));
+  });
+
+  function makeMinimalData(version, extraQueue = []) {
+    return {
+      currentSong: null,
+      queue: extraQueue,
+      recent: [],
+      isPaused: false,
+      version,
+      playedCount: 0,
+    };
+  }
+
+  test('call without version is never discarded by stale-guard', async () => {
+    // With version=-1 (absent) the stale-guard should be skipped entirely.
+    // Since there is no client set, _doFlush bails early — but it must not
+    // throw and must not be silently swallowed by the stale check.
+    // We just assert it returns without throwing.
+    const data = { currentSong: null, queue: [], recent: [] }; // no version field
+    await expect(Announcer.updateGuildStatus('g-no-version', data)).resolves.toBeUndefined();
+  });
+
+  test('second call with lower version is discarded', async () => {
+    // Manually set renderedVersionByGuild to simulate that version 5 was already drawn
+    Announcer['renderedVersionByGuild'].set('g-stale', 5);
+
+    // Spy on _doFlush to confirm it is NOT called
+    const doFlushSpy = jest.spyOn(Announcer, '_doFlush');
+
+    await Announcer.updateGuildStatus('g-stale', makeMinimalData(3));
+
+    expect(doFlushSpy).not.toHaveBeenCalled();
+    doFlushSpy.mockRestore();
+  });
+
+  test('call with same version as rendered is also discarded', async () => {
+    Announcer['renderedVersionByGuild'].set('g-same', 7);
+    const doFlushSpy = jest.spyOn(Announcer, '_doFlush');
+
+    await Announcer.updateGuildStatus('g-same', makeMinimalData(7));
+
+    expect(doFlushSpy).not.toHaveBeenCalled();
+    doFlushSpy.mockRestore();
+  });
+
+  test('call with higher version proceeds to _doFlush', async () => {
+    Announcer['renderedVersionByGuild'].set('g-fresh', 3);
+    const doFlushSpy = jest.spyOn(Announcer, '_doFlush').mockResolvedValue(undefined);
+
+    await Announcer.updateGuildStatus('g-fresh', makeMinimalData(5));
+
+    expect(doFlushSpy).toHaveBeenCalledTimes(1);
+    doFlushSpy.mockRestore();
+  });
+
+  test('concurrent calls: second is blocked by mutex and returns early', async () => {
+    // Simulate a flush already in flight by marking the guild as flushing
+    Announcer['flushingByGuild'].add('g-mutex');
+    Announcer['renderedVersionByGuild'].set('g-mutex', 0); // so version 5 > 0 passes stale-guard
+
+    const doFlushSpy = jest.spyOn(Announcer, '_doFlush').mockResolvedValue(undefined);
+
+    await Announcer.updateGuildStatus('g-mutex', makeMinimalData(5));
+
+    // _doFlush should NOT be called because the mutex is held
+    expect(doFlushSpy).not.toHaveBeenCalled();
+    doFlushSpy.mockRestore();
+
+    // cleanup
+    Announcer['flushingByGuild'].delete('g-mutex');
+  });
+});


### PR DESCRIPTION
## O que este PR conserta

### Causas-raiz do mismatch (estado exibido ≠ estado real)

**1. pause/resume nunca atualizavam o embed**
`MusicManager.pause()` e `resume()` não chamavam `pushStatus`. O embed ficava mostrando "Tocando Agora" mesmo após pausar. Corrigido: ambos agora setam `isPaused` de forma síncrona e chamam `bumpAndPushStatus`.

**2. Edições fire-and-forget sem ordenação (stale overwrite)**
`void Announcer.updateGuildStatus(...)` era disparado ~10 vezes de lugares diferentes sem nenhum controle de ordem. O resultado async mais lento vencia, mesmo carregando um snapshot desatualizado — sobrescrevendo o estado novo com o antigo. Corrigido: Announcer agora mantém `renderedVersionByGuild` + `flushingByGuild`. Qualquer flush com `version <= lastDrawn` é descartado antes de tocar o Discord.

**3. Fila passada por referência ao array vivo**
`pushStatus` passava `queue: guildData.queue` (referência). `buildStatusEmbed` é async (faz `user.fetch`, `channels.fetch`) — o array podia sofrer `shift/push` entre o disparo e o render. Corrigido: `pushStatus` agora passa `queue: guildData.queue.slice()` e `recent: guildData.recentlyPlayed.slice()` — snapshot imutável no momento da captura.

**4. Contador "Já Tocaram (N)" travado em 6**
O label usava `recent.length` (array capado em 6) → mostrava "6" para sempre. Corrigido: novo campo `playedCount` em `GuildMusicData`, incrementado no evento `AudioPlayerStatus.Idle` e resetado em `stop()`/idle-verdadeiro. O embed usa `playedCount` como número no label; a lista visual continua mostrando os últimos 6.

---

## O que foi alterado

### `src/types/music.ts`
- Adicionado `version: number` — incrementa em todo mutador que afeta o que o embed mostra
- Adicionado `playedCount?: number` — total real de faixas tocadas na sessão

### `src/services/MusicManager.ts`
- `getGuildData()` inicializa `version: 0, playedCount: 0`
- Novo helper privado `bumpAndPushStatus()` — incrementa version + chama pushStatus
- `pushStatus()` monta snapshot imutável: `queue.slice()`, `recent.slice()`, `isPaused`, `version`, `playedCount`
- Todos os mutadores de estado usam `bumpAndPushStatus`
- Thumbnail-fill mantém `pushStatus` simples (cosmético, não muda versão lógica)
- `pause()` / `resume()`: setam `isPaused` de forma síncrona + `bumpAndPushStatus`
- `AudioPlayerStatus.Idle`: incrementa `playedCount`; reset em idle-verdadeiro e `stop()`
- `skip()`: aceita `by?/byId?` opcionais, registra `lastSkip` metadata

### `src/services/Announcer.ts`
- `updateGuildStatus` aceita `isPaused`, `version`, `playedCount`
- Stale-guard duplo: na entrada + após o `channel.fetch` async
- Mutex simples via `flushingByGuild`
- `buildStatusEmbed`: título "⏸️ Pausada" + cor distinta quando `isPaused`
- "Já Tocaram (N)": usa `playedCount` no número; fallback para `recent.length`

### `tests/statusStateVersioned.test.js` (novo)
13 testes cobrindo inicialização, bumps em mutadores, pause/resume, playedCount e stale-guard.

---

## Smoke pós-deploy

1. `/play <playlist>` → `/pause` → embed deve mostrar "⏸️ Pausada"
2. `/resume` → embed volta "Tocando Agora"
3. `/shuffle` + `/skip` rápido → fila não deve "voltar" a snapshot antigo
4. Tocar 7+ músicas → contador "Já Tocaram (N)" cresce além de 6

> **Aviso:** monitorar o canal de status nos primeiros minutos. Verificar que: pause/resume refletem, sem duplicação de embeds, sem `update_guild_status_failed` no log.

---

## Fora do escopo (PR2+)

StatusRenderer / render puro / persistência de messageId / botões ⏯⏭🔀⏹ / Components V2 / refactor god-object — todos são PRs separados.

---
🏗 Built by VHXCO Agentic Software House