### PR TITLE
fix(youtube): restaurar YouTube via EJS n-sig solver (yt-dlp-ejs + web,tv)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,6 +31,8 @@ FROM node:22-alpine3.20 AS production
 
 # yt-dlp version to bake — override at build time with --build-arg YTDLP_VERSION=...
 ARG YTDLP_VERSION=2026.06.09
+# EJS n-sig solver — override with --build-arg YTDLP_EJS_VERSION=...
+ARG YTDLP_EJS_VERSION=0.8.0
 
 # Runtime deps:
 #   ffmpeg        — audio transcoding
@@ -39,10 +41,13 @@ ARG YTDLP_VERSION=2026.06.09
 #   libstdc++     — required at runtime by @discordjs/opus compiled from source (musl build)
 RUN apk add --no-cache ffmpeg python3 py3-pip su-exec libstdc++
 
-# Install yt-dlp via pip (supports both linux/amd64 and linux/arm64 transparently).
+# Install yt-dlp + EJS n-sig solver via pip (supports both linux/amd64 and linux/arm64 transparently).
 # --break-system-packages is required on Alpine ≥3.20 (PEP-668 enforced).
-# Pinned to YTDLP_VERSION for reproducibility; bump the ARG above to update.
-RUN pip install --no-cache-dir --break-system-packages "yt-dlp==${YTDLP_VERSION}"
+# yt-dlp-ejs ships the JavaScript challenge-solver script used by the EJS framework;
+# node (/usr/local/bin/node) is the JS runtime — no deno required.
+RUN pip install --no-cache-dir --break-system-packages \
+    "yt-dlp==${YTDLP_VERSION}" \
+    "yt-dlp-ejs==${YTDLP_EJS_VERSION}"
 
 WORKDIR /app
 COPY package*.json ./
@@ -54,6 +59,11 @@ COPY --from=builder /app/dist ./dist
 COPY musa.png ./
 
 RUN mkdir -p /app/logs
+
+# Cache dir writable pelo uid 1001 (musa) — o EJS solver e o yt-dlp usam XDG_CACHE_HOME.
+# Sem isso o yt-dlp-ejs falha silenciosamente ao tentar cachear o script.
+RUN mkdir -p /app/.cache
+ENV XDG_CACHE_HOME=/app/.cache
 
 RUN addgroup -g 1001 -S nodejs && adduser -S musa -u 1001
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -5,5 +5,11 @@ set -e
 mkdir -p /app/logs || true
 chown -R 1001:1001 /app/logs 2>/dev/null || true
 
+# Cache dir para o EJS solver do yt-dlp (XDG_CACHE_HOME=/app/.cache)
+# O yt-dlp-ejs e o yt-dlp usam este diretório para cachear o script solver.
+# Sem ownership correto o download do solver falha silenciosamente.
+mkdir -p /app/.cache || true
+chown -R 1001:1001 /app/.cache 2>/dev/null || true
+
 # Switch to user 'musa' and execute the command
 exec su-exec 1001:1001 "$@"

--- a/src/services/ResolverYouTubeService.ts
+++ b/src/services/ResolverYouTubeService.ts
@@ -5,7 +5,7 @@ import axios from 'axios';
 import { botConfig } from '../config';
 import { spawn } from 'child_process';
 import { isYouTubeVideoUrl } from '../utils/providers';
-import { YTDLP_USER_AGENT } from '../utils/ytdlp';
+import { buildYtDlpBaseArgs } from '../utils/ytdlp';
 
 export class ResolverYouTubeService extends BaseMusicService {
   private readonly resolverUrl: string | null;
@@ -125,8 +125,9 @@ export class ResolverYouTubeService extends BaseMusicService {
 
   private async searchWithDirectYtDlp(query: string, maxResults: number): Promise<MusicSource[]> {
     return new Promise((resolve) => {
-      // Prefer Music client first via extractor-args, then fallback to default clients
-      const trySearch = (engine: 'music' | 'default') =>
+      // Single pass with web,tv client — avoids ios/mweb (GVS PoToken) and uses
+      // the EJS n-sig solver (yt-dlp-ejs + --js-runtimes node from buildYtDlpBaseArgs).
+      const trySearch = () =>
         new Promise<MusicSource[]>((res) => {
           const searchQuery = `ytsearch${maxResults}:${query}`;
 
@@ -134,10 +135,10 @@ export class ResolverYouTubeService extends BaseMusicService {
             query,
             maxResults,
             method: 'direct_ytdlp',
-            engine,
+            playerClient: 'web,tv',
           });
 
-          // Optimized yt-dlp flags as fallback — UA from shared util
+          // Optimized yt-dlp flags as fallback — UA + proxy + EJS from shared util
           const ytDlpArgs = [
             '--dump-json',
             '--default-search',
@@ -147,26 +148,14 @@ export class ResolverYouTubeService extends BaseMusicService {
             '--skip-download',
             '--quiet',
             '--ignore-errors',
-            '--socket-timeout',
-            String(botConfig.ytdlpSocketTimeoutSeconds ?? 15),
-            '--user-agent',
-            YTDLP_USER_AGENT,
             '--max-downloads',
             maxResults.toString(),
+            ...buildYtDlpBaseArgs({ includeSocketTimeout: true, includeProxy: true }),
+            // player_client=web,tv: avoids ios/mweb (GVS PoToken required);
+            // EJS n-sig solver handles signature resolution for web,tv.
+            '--extractor-args',
+            'youtube:player_client=web,tv',
           ];
-
-          // Proxy: WARP must be used for fallback path too
-          const searchProxy = botConfig.ytdlpProxy;
-          if (searchProxy) {
-            ytDlpArgs.push('--proxy', searchProxy);
-          }
-
-          // Prefer web_music on first pass; fallback uses default (explicit for clarity)
-          if (engine === 'music') {
-            ytDlpArgs.push('--extractor-args', 'youtube:player_client=web_music,web');
-          } else {
-            ytDlpArgs.push('--extractor-args', 'youtube:player_client=default');
-          }
 
           ytDlpArgs.push(searchQuery);
 
@@ -175,8 +164,8 @@ export class ResolverYouTubeService extends BaseMusicService {
             args: ytDlpArgs.join(' '),
             query,
             method: 'direct_ytdlp',
-            engine,
-            hasProxy: !!searchProxy,
+            playerClient: 'web,tv',
+            hasProxy: !!botConfig.ytdlpProxy,
           });
 
           const ytDlp = spawn('yt-dlp', ytDlpArgs);
@@ -188,7 +177,7 @@ export class ResolverYouTubeService extends BaseMusicService {
           const timeoutId = setTimeout(() => {
             isTimedOut = true;
             ytDlp.kill('SIGKILL');
-            logEvent('resolver_ytdlp_timeout', { query, timeout: 30000, engine });
+            logEvent('resolver_ytdlp_timeout', { query, timeout: 30000, playerClient: 'web,tv' });
           }, 30000);
 
           ytDlp.stdout.on('data', (data) => {
@@ -203,7 +192,7 @@ export class ResolverYouTubeService extends BaseMusicService {
             clearTimeout(timeoutId);
 
             if (isTimedOut) {
-              logEvent('resolver_ytdlp_timed_out', { query, engine });
+              logEvent('resolver_ytdlp_timed_out', { query, playerClient: 'web,tv' });
               return res([]);
             }
 
@@ -212,7 +201,7 @@ export class ResolverYouTubeService extends BaseMusicService {
                 query,
                 exitCode: code,
                 method: 'direct_ytdlp',
-                engine,
+                playerClient: 'web,tv',
               });
               return res([]);
             }
@@ -248,7 +237,7 @@ export class ResolverYouTubeService extends BaseMusicService {
                 logError('Failed to parse yt-dlp JSON output line', parseError as Error, {
                   line: line.substring(0, 100) + (line.length > 100 ? '...' : ''),
                   method: 'direct_ytdlp',
-                  engine,
+                  playerClient: 'web,tv',
                 });
                 continue;
               }
@@ -258,7 +247,7 @@ export class ResolverYouTubeService extends BaseMusicService {
               query,
               resultsCount: results.length,
               method: 'direct_ytdlp',
-              engine,
+              playerClient: 'web,tv',
             });
 
             res(results);
@@ -268,17 +257,14 @@ export class ResolverYouTubeService extends BaseMusicService {
             logError('Direct yt-dlp process error', error, {
               query,
               method: 'direct_ytdlp',
-              engine,
+              playerClient: 'web,tv',
             });
             res([]);
           });
         });
 
-      // Execute with Music client first, fallback to default clients
-      trySearch('music').then((list) => {
-        if (list.length > 0) return resolve(list);
-        return trySearch('default').then(resolve);
-      });
+      // Single pass — web,tv client handles n-sig via EJS solver
+      trySearch().then(resolve);
     });
   }
 
@@ -352,21 +338,18 @@ export class ResolverYouTubeService extends BaseMusicService {
         method: 'direct_ytdlp',
       });
 
-      // Use yt-dlp directly to get stream URL — UA from shared util
+      // Use yt-dlp directly to get stream URL — UA + proxy + EJS from shared util.
+      // player_client=web,tv: avoids ios/mweb (GVS PoToken required); EJS n-sig
+      // solver handles signature resolution for web,tv without bgutil.
       const ytDlpArgs = [
         '--get-url',
         '--no-warnings',
         '--format',
         'bestaudio[ext=webm]/bestaudio[ext=m4a]/bestaudio',
-        '--user-agent',
-        YTDLP_USER_AGENT,
+        ...buildYtDlpBaseArgs({ includeProxy: true }),
+        '--extractor-args',
+        'youtube:player_client=web,tv',
       ];
-
-      // Proxy: direct fallback must route through WARP too
-      const streamProxy = botConfig.ytdlpProxy;
-      if (streamProxy) {
-        ytDlpArgs.push('--proxy', streamProxy);
-      }
 
       ytDlpArgs.push(url);
 
@@ -375,7 +358,8 @@ export class ResolverYouTubeService extends BaseMusicService {
         args: ytDlpArgs.join(' '),
         url,
         method: 'direct_ytdlp',
-        hasProxy: !!streamProxy,
+        playerClient: 'web,tv',
+        hasProxy: !!botConfig.ytdlpProxy,
       });
 
       const ytDlp = spawn('yt-dlp', ytDlpArgs);

--- a/src/services/YouTubeService.ts
+++ b/src/services/YouTubeService.ts
@@ -21,18 +21,16 @@ export class YouTubeService extends BaseMusicService {
       logEvent('youtube_search_started', {
         query,
         maxResults,
-        prefer: 'music_first',
+        playerClient: 'web,tv',
       });
 
-      // First pass: prefer Music client via extractor-args; fallback: default clients
-      const musicFirst = await this.searchWithYtDlp(query, maxResults, 'music');
-      const results =
-        musicFirst.length > 0 ? musicFirst : await this.searchWithYtDlp(query, maxResults, 'default');
+      // Single pass with web,tv client — avoids ios/mweb (GVS PoToken) and uses
+      // the EJS n-sig solver (yt-dlp-ejs + --js-runtimes node).
+      const results = await this.searchWithYtDlp(query, maxResults);
 
       logEvent('youtube_search_completed', {
         query,
         resultsCount: results.length,
-        used: musicFirst.length > 0 ? 'music_client' : 'default',
       });
 
       return results;
@@ -45,11 +43,7 @@ export class YouTubeService extends BaseMusicService {
     }
   }
 
-  private async searchWithYtDlp(
-    query: string,
-    maxResults: number,
-    engine: 'music' | 'default' = 'music',
-  ): Promise<MusicSource[]> {
+  private async searchWithYtDlp(query: string, maxResults: number): Promise<MusicSource[]> {
     return new Promise((resolve) => {
       const searchQuery = `ytsearch${maxResults}:${query}`;
 
@@ -61,12 +55,12 @@ export class YouTubeService extends BaseMusicService {
         ...buildYtDlpBaseArgs({ includeProxy: true }),
       ];
 
-      // Prefer Music client first; fallback uses default
-      if (engine === 'music') {
-        ytDlpArgs.push('--extractor-args', 'youtube:player_client=web_music,web');
-      } else {
-        ytDlpArgs.push('--extractor-args', 'youtube:player_client=default');
-      }
+      // player_client=web,tv: evita ios/mweb (que exigem GVS PoToken) e usa
+      // clients que o EJS n-sig solver suporta. 'tv' como fallback interno do
+      // yt-dlp contorna o bug "0 sig function possibilities" presente em web puro.
+      // web_music foi removido pois exige resolução EJS adicional e não trouxe
+      // ganho real; web,tv cobre search e resolve opus sem GVS PoToken.
+      ytDlpArgs.push('--extractor-args', 'youtube:player_client=web,tv');
 
       // Add the search query
       ytDlpArgs.push(searchQuery);
@@ -75,7 +69,7 @@ export class YouTubeService extends BaseMusicService {
         command: 'yt-dlp',
         args: ytDlpArgs.join(' '),
         query,
-        engine,
+        playerClient: 'web,tv',
         hasProxy: !!botConfig.ytdlpProxy,
       });
 
@@ -170,13 +164,17 @@ export class YouTubeService extends BaseMusicService {
         let output = '';
         let errorOutput = '';
 
-        // Use yt-dlp to get the actual stream URL — UA + proxy from shared util
+        // Use yt-dlp to get the actual stream URL — UA + proxy + EJS from shared util.
+        // player_client=web,tv: avoids ios/mweb (requires GVS PoToken); EJS solver
+        // handles the n-sig for web,tv without any additional PoToken provider.
         const ytDlpArgs = [
           '--get-url',
           '--format',
           'bestaudio[ext=m4a]/bestaudio/best',
           '--no-playlist',
           ...buildYtDlpBaseArgs({ includeProxy: true }),
+          '--extractor-args',
+          'youtube:player_client=web,tv',
           source.url,
         ];
 
@@ -245,13 +243,16 @@ export class YouTubeService extends BaseMusicService {
   } | null> {
     return new Promise((resolve) => {
       let output = '';
-      // UA + proxy + socket-timeout from shared util; URL appended last
+      // UA + proxy + socket-timeout + EJS from shared util; URL appended last.
+      // player_client=web,tv: same as search/stream — avoids GVS PoToken clients.
       const args = [
         '--dump-json',
         '--no-warnings',
         '--skip-download',
         '--geo-bypass',
         ...buildYtDlpBaseArgs({ includeSocketTimeout: true, includeProxy: true }),
+        '--extractor-args',
+        'youtube:player_client=web,tv',
         videoUrl,
       ];
 
@@ -301,7 +302,9 @@ export class YouTubeService extends BaseMusicService {
     //   4. anything else (worst case)
     const format = 'bestaudio[acodec=opus]/bestaudio[ext=webm]/bestaudio[ext=m4a]/bestaudio';
 
-    // UA + socket-timeout + proxy (WARP) from shared util
+    // UA + socket-timeout + proxy (WARP) + EJS n-sig solver from shared util.
+    // player_client=web,tv: avoids ios/mweb (requires GVS PoToken); the EJS solver
+    // (yt-dlp-ejs package + --js-runtimes node) handles n-sig for web,tv.
     const ytDlpArgs: string[] = [
       '--no-playlist',
       '--format',
@@ -315,6 +318,8 @@ export class YouTubeService extends BaseMusicService {
       '--fragment-retries',
       '10', // retry individual fragments before giving up the track
       ...buildYtDlpBaseArgs({ includeSocketTimeout: true, includeProxy: true }),
+      '--extractor-args',
+      'youtube:player_client=web,tv',
     ];
 
     if (!botConfig.ytdlpProxy) {

--- a/src/services/providers/YouTubePlaylistProvider.ts
+++ b/src/services/providers/YouTubePlaylistProvider.ts
@@ -42,7 +42,8 @@ export class YouTubePlaylistProvider implements PlaylistProvider {
     while (yielded < limit) {
       const remaining = limit === Infinity ? pageSize : Math.min(pageSize, limit - yielded);
       const end = start + remaining - 1;
-      // UA + proxy + socket-timeout from shared util; URL appended last
+      // UA + proxy + socket-timeout + EJS from shared util; URL appended last.
+      // player_client=web,tv: avoids ios/mweb (GVS PoToken) for playlist fetches.
       const args: string[] = [
         '--dump-json',
         '--flat-playlist',
@@ -50,6 +51,8 @@ export class YouTubePlaylistProvider implements PlaylistProvider {
         '--geo-bypass',
         '--ignore-errors',
         ...buildYtDlpBaseArgs({ includeSocketTimeout: true, includeProxy: true }),
+        '--extractor-args',
+        'youtube:player_client=web,tv',
         '--playlist-start',
         String(start),
         '--playlist-end',

--- a/src/utils/ytdlp.ts
+++ b/src/utils/ytdlp.ts
@@ -2,9 +2,19 @@
  * Shared yt-dlp helpers — single source of truth for args and spawn wrapper.
  *
  * Each call-site adds its own specific flags on top of the base args.
- * This util covers: User-Agent constant, proxy flag, socket-timeout flag.
+ * This util covers: User-Agent constant, proxy flag, socket-timeout flag,
+ * and the EJS n-sig solver flags (--js-runtimes node).
  * It intentionally does NOT include search-query, --format, -o, --get-url, etc.
  * — those are call-site specific.
+ *
+ * EJS n-sig solver (why it's here):
+ *   Since late 2025 yt-dlp moved n-param/signature resolution to the EJS
+ *   (External JavaScript) framework. Without --js-runtimes, yt-dlp logs
+ *   "Signature solving failed" even on valid URLs. The package yt-dlp-ejs
+ *   (installed in the Docker image) ships the solver script; node is the
+ *   runtime (/usr/local/bin/node already present in the Alpine image).
+ *   XDG_CACHE_HOME=/app/.cache (set in Dockerfile + entrypoint) makes the
+ *   cache dir writable for uid 1001 (musa).
  */
 import { spawn } from 'child_process';
 import { botConfig } from '../config';
@@ -24,14 +34,16 @@ export const YTDLP_USER_AGENT =
  *
  * @param opts.includeSocketTimeout - add --socket-timeout (for meta/playlist calls). Default false.
  * @param opts.includeProxy - add --proxy when configured. Default true.
+ * @param opts.includeEjs - add --js-runtimes node for EJS n-sig solving. Default true.
  */
 export function buildYtDlpBaseArgs(
   opts: {
     includeSocketTimeout?: boolean;
     includeProxy?: boolean;
+    includeEjs?: boolean;
   } = {},
 ): string[] {
-  const { includeSocketTimeout = false, includeProxy = true } = opts;
+  const { includeSocketTimeout = false, includeProxy = true, includeEjs = true } = opts;
 
   const args: string[] = ['--user-agent', YTDLP_USER_AGENT];
 
@@ -41,6 +53,12 @@ export function buildYtDlpBaseArgs(
 
   if (includeSocketTimeout) {
     args.push('--socket-timeout', String(botConfig.ytdlpSocketTimeoutSeconds ?? 20));
+  }
+
+  // EJS n-sig solver: use node as the JS runtime for signature/n-challenge resolution.
+  // Requires yt-dlp-ejs package (installed in Dockerfile) and XDG_CACHE_HOME writable.
+  if (includeEjs) {
+    args.push('--js-runtimes', 'node');
   }
 
   return args;


### PR DESCRIPTION
## Diagnóstico

O YouTube parou de funcionar em prod porque **dois problemas independentes** estavam ativos simultaneamente:

1. **n-sig solver ausente** — o yt-dlp 2026.06.09 delega a resolução de assinatura/n-param ao framework **EJS** (External JavaScript). O container tinha `node` mas não tinha o **script solver** (`yt-dlp-ejs`), causando o erro `"Signature solving failed (EJS)"`.
2. **player_client errado** — os clients `ios`/`mweb` (e `web_music`) exigem **GVS PoToken**, que não estava configurado. Trocar para `web,tv` elimina esse requisito.

**bgutil/PoToken NÃO é necessário** com essa combinação — confirmado em teste direto no container de prod.

## Solução

### Dockerfile
- Instala `yt-dlp-ejs==0.8.0` no mesmo `pip install` do yt-dlp (novo `ARG YTDLP_EJS_VERSION=0.8.0` para reprodutibilidade)
- Cria `/app/.cache` + `ENV XDG_CACHE_HOME=/app/.cache` para o solver cachear como uid 1001

### entrypoint.sh
- `chown -R 1001:1001 /app/.cache` antes do `su-exec` (sem isso o solver não consegue gravar cache)

### `src/utils/ytdlp.ts` (`buildYtDlpBaseArgs`)
- Adiciona `--js-runtimes node` por padrão (`includeEjs=true`) — propaga automaticamente a **todos** os call-sites de yt-dlp

### `src/services/YouTubeService.ts`
- Substitui `player_client=web_music,web` e `player_client=default` por `player_client=web,tv` em **search**, **getStreamUrl**, **fetchMeta** e **spawnPipeStream**
- Remove o fallback de dois passes `music->default` (ambos usavam o mesmo client agora — single pass)

### `src/services/ResolverYouTubeService.ts`
- Mesmo `player_client=web,tv` + `buildYtDlpBaseArgs` em `searchWithDirectYtDlp` e `getStreamUrlWithDirectYtDlp`
- Remove import nao-usado `YTDLP_USER_AGENT`

### `src/services/providers/YouTubePlaylistProvider.ts`
- Adiciona `player_client=web,tv` no fetch de playlists

## Combo confirmado empiricamente

```sh
yt-dlp --proxy $WARP \
  --js-runtimes node \
  --extractor-args "youtube:player_client=web,tv" \
  -f "bestaudio[acodec=opus]/bestaudio[ext=webm]/bestaudio[ext=m4a]/bestaudio" \
  --get-url "https://www.youtube.com/watch?v=<id>"
```
Retornou URL de audio opus sem sign-in, sem bgutil, sem GVS PoToken.

## Validacao tecnica

- `npm run build` — verde (0 errors)
- `npm run lint` — 0 errors (69 warnings pre-existentes de no-explicit-any)
- `npm test` — 26/26 testes passando

## Smoke obrigatorio pos-deploy

> **O YouTube estava QUEBRADO em prod no momento deste PR. O smoke `/play` real no Discord e obrigatorio para confirmar o fix.**

Checklist para o Vitor revisar:
- [ ] Deploy da nova imagem (novo pip install com yt-dlp-ejs)
- [ ] `/play <musica>` toca audio do YouTube sem erro nos logs
- [ ] Logs nao mostram `youtube_pipe_stream_ytdlp_exit_nonzero` com "Signature solving failed"
- [ ] `/play` de 3-4 musicas seguidas sem 429 (WARP aguenta)
- [ ] Se ainda aparecer "Sign in to confirm you're not a bot" apos o deploy -> sinal para Fase 2 (bgutil)

---
Built by VHXCO Builder <ops@vhxco.io>