### PR TITLE
feat(soundcloud): SoundCloud fallback when YouTube fails

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -15,11 +15,13 @@ ENABLE_YOUTUBE=false
 ENABLE_INTERNET_ARCHIVE=true
 ENABLE_RADIO=true
 ENABLE_SPOTIFY=false
+ENABLE_SOUNDCLOUD=true        # SoundCloud fallback (no proxy needed — works from datacenter)
 
 # Service Priorities (lower number = higher priority)
 YOUTUBE_PRIORITY=3
 INTERNET_ARCHIVE_PRIORITY=2
 RADIO_PRIORITY=1
+SOUNDCLOUD_PRIORITY=4         # Fallback: queried only when YouTube returns empty
 
 # Search Configuration
 MAX_RESULTS_PER_SOURCE=3

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -53,10 +53,12 @@ const EnvSchema = z.object({
   ENABLE_INTERNET_ARCHIVE: bool().optional().default(true),
   ENABLE_RADIO: bool().optional().default(true),
   ENABLE_SPOTIFY: bool().optional().default(false),
+  ENABLE_SOUNDCLOUD: bool().optional().default(true),
 
   YOUTUBE_PRIORITY: intInRange(1, 10, 3).optional().default(3),
   INTERNET_ARCHIVE_PRIORITY: intInRange(1, 10, 2).optional().default(2),
   RADIO_PRIORITY: intInRange(1, 10, 1).optional().default(1),
+  SOUNDCLOUD_PRIORITY: intInRange(1, 10, 4).optional().default(4),
   MAX_RESULTS_PER_SOURCE: intInRange(1, 25, 3).optional().default(3),
 
   MAX_QUEUE_SIZE: intInRange(1, 1000, 100).optional().default(100),
@@ -128,6 +130,11 @@ export function loadBotConfig(): BotConfig {
       radio: {
         enabled: env.ENABLE_RADIO as boolean,
         priority: env.RADIO_PRIORITY as number,
+        maxResults: env.MAX_RESULTS_PER_SOURCE as number,
+      },
+      soundcloud: {
+        enabled: env.ENABLE_SOUNDCLOUD as boolean,
+        priority: env.SOUNDCLOUD_PRIORITY as number,
         maxResults: env.MAX_RESULTS_PER_SOURCE as number,
       },
     },

--- a/src/services/MultiSourceManager.ts
+++ b/src/services/MultiSourceManager.ts
@@ -4,6 +4,7 @@ import { RadioService } from './RadioService';
 import { InternetArchiveService } from './InternetArchiveService';
 import { YouTubeService } from './YouTubeService';
 import { ResolverYouTubeService } from './ResolverYouTubeService';
+import { SoundCloudService } from './SoundCloudService';
 import { botConfig } from '../config';
 import { logEvent, logError, logWarning } from '../utils/logger';
 import { isYouTubeVideoUrl } from '../utils/providers';
@@ -48,6 +49,15 @@ export class MultiSourceManager {
       });
     }
 
+    // SoundCloud — fallback when YouTube returns empty/fails (priority > YouTube)
+    services.push(
+      new SoundCloudService(botConfig.services.soundcloud.priority, botConfig.services.soundcloud.enabled),
+    );
+    logEvent('soundcloud_service_initialized', {
+      priority: botConfig.services.soundcloud.priority,
+      enabled: botConfig.services.soundcloud.enabled,
+    });
+
     this.services.push(...services);
 
     // Filter enabled services and sort by priority
@@ -78,7 +88,25 @@ export class MultiSourceManager {
       enabledServices: this.enabledServices.length,
     });
 
-    const searchPromises = this.enabledServices.map(async (service) => {
+    // Tier separation for waterfall fallback:
+    //  - FALLBACK_SERVICES: only queried when all primary music sources return empty
+    //  - PASSTHROUGH_SERVICES: fan-out alongside primaries (radio/IA unchanged behaviour)
+    //  - Everything else is "primary" (youtube / resolver-youtube)
+    const FALLBACK_SERVICES: ServiceType[] = ['soundcloud'];
+    const PASSTHROUGH_SERVICES: ServiceType[] = ['radio', 'internet_archive'];
+
+    const passthroughEnabled = this.enabledServices.filter((s) =>
+      PASSTHROUGH_SERVICES.includes(s.getServiceName()),
+    );
+    const primaryEnabled = this.enabledServices.filter(
+      (s) =>
+        !FALLBACK_SERVICES.includes(s.getServiceName()) && !PASSTHROUGH_SERVICES.includes(s.getServiceName()),
+    );
+    const fallbackEnabled = this.enabledServices.filter((s) =>
+      FALLBACK_SERVICES.includes(s.getServiceName()),
+    );
+
+    const runService = async (service: BaseMusicService): Promise<MusicSource[]> => {
       try {
         const results = await service.search(query, maxResultsPerService);
         logEvent('service_search_completed', {
@@ -94,11 +122,27 @@ export class MultiSourceManager {
         });
         return [];
       }
-    });
+    };
 
     try {
-      const allResults = await Promise.all(searchPromises);
-      const combinedResults = allResults.flat();
+      // Fan-out primaries + passthrough in parallel (existing behaviour for these tiers)
+      const [primaryResults, passthroughResults] = await Promise.all([
+        Promise.all(primaryEnabled.map(runService)).then((r) => r.flat()),
+        Promise.all(passthroughEnabled.map(runService)).then((r) => r.flat()),
+      ]);
+
+      // Waterfall: only query SoundCloud if all primary sources returned nothing
+      let fallbackResults: MusicSource[] = [];
+      if (primaryResults.length === 0 && fallbackEnabled.length > 0) {
+        logEvent('soundcloud_fallback_triggered', {
+          query,
+          reason: 'primary_sources_returned_empty',
+          fallbackServices: fallbackEnabled.map((s) => s.getServiceName()),
+        });
+        fallbackResults = (await Promise.all(fallbackEnabled.map(runService))).flat();
+      }
+
+      const combinedResults = [...primaryResults, ...fallbackResults, ...passthroughResults];
 
       // Filter out non-video YouTube entries (channels/playlists) — canonical util
       const filteredResults = combinedResults.filter((r) => {
@@ -112,6 +156,7 @@ export class MultiSourceManager {
       logEvent('multi_source_search_completed', {
         query,
         totalResults: sortedResults.length,
+        usedFallback: fallbackResults.length > 0,
         resultsByService: this.getResultsCountByService(filteredResults),
       });
 

--- a/src/services/MusicManager.ts
+++ b/src/services/MusicManager.ts
@@ -356,7 +356,9 @@ export class MusicManager {
       let resource;
       if (song.service === 'radio' || song.service === 'internet_archive') {
         resource = await this.createRadioResource(song.url);
-      } else if (song.service === 'youtube') {
+      } else if (song.service === 'youtube' || song.service === 'soundcloud') {
+        // SoundCloud URLs are also resolved + piped by yt-dlp — same path as YouTube.
+        // No proxy/cookies needed for SoundCloud (rate-limit by client_id, not IP).
         resource = await this.createYouTubeStreamResource(guildId, song);
       } else {
         resource = createAudioResource(song.url, {

--- a/src/services/SoundCloudService.ts
+++ b/src/services/SoundCloudService.ts
@@ -1,0 +1,158 @@
+import { BaseMusicService } from './BaseMusicService';
+import { MusicSource } from '../types/music';
+import { logEvent, logError } from '../utils/logger';
+import { spawn } from 'child_process';
+
+/**
+ * SoundCloudService — searches and streams via yt-dlp's scsearch extractor.
+ *
+ * Key differences from YouTubeService:
+ *  - No proxy (SoundCloud rate-limits per client_id, not by IP — works from datacenter)
+ *  - No --extractor-args player_client (YouTube-only flag)
+ *  - No cookie handling (not needed for public tracks)
+ *  - scsearch${N}:${query} instead of ytsearch${N}:${query}
+ *
+ * Playback: SoundCloud URLs go through the same yt-dlp pipe-stream path as YouTube
+ * (createYouTubeStreamResource in MusicManager). They contain soundcloud.com in the
+ * hostname, which is how MusicManager will route them.
+ */
+export class SoundCloudService extends BaseMusicService {
+  constructor(priority: number, enabled: boolean) {
+    super('soundcloud', priority, enabled);
+  }
+
+  async search(query: string, maxResults = 3): Promise<MusicSource[]> {
+    if (!this.isEnabled()) {
+      return [];
+    }
+
+    try {
+      logEvent('soundcloud_search_started', { query, maxResults });
+      const results = await this.searchWithYtDlp(query, maxResults);
+      logEvent('soundcloud_search_completed', { query, resultsCount: results.length });
+      return results;
+    } catch (error) {
+      logError('SoundCloud search failed', error as Error, { query, maxResults });
+      return [];
+    }
+  }
+
+  private searchWithYtDlp(query: string, maxResults: number): Promise<MusicSource[]> {
+    return new Promise((resolve) => {
+      const searchQuery = `scsearch${maxResults}:${query}`;
+
+      // Minimal args: no proxy, no cookies, no player_client — SoundCloud doesn't need them.
+      const ytDlpArgs = [
+        '--dump-json',
+        '--no-warnings',
+        '--skip-download',
+        '--flat-playlist',
+        '--user-agent',
+        'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/118.0.0.0 Safari/537.36',
+        searchQuery,
+      ];
+
+      logEvent('soundcloud_ytdlp_command', {
+        command: 'yt-dlp',
+        args: ytDlpArgs.join(' '),
+        query,
+      });
+
+      const ytDlp = spawn('yt-dlp', ytDlpArgs);
+
+      let output = '';
+      let errorOutput = '';
+
+      ytDlp.stdout.on('data', (data) => {
+        output += data.toString();
+      });
+
+      ytDlp.stderr.on('data', (data) => {
+        errorOutput += data.toString();
+      });
+
+      ytDlp.on('close', (code) => {
+        if (code !== 0) {
+          logError('yt-dlp SoundCloud search failed', new Error(errorOutput), {
+            query,
+            exitCode: code,
+          });
+          return resolve([]);
+        }
+
+        try {
+          const results: MusicSource[] = [];
+          const lines = output
+            .trim()
+            .split('\n')
+            .filter((line) => line.trim());
+
+          for (const line of lines) {
+            try {
+              const track = JSON.parse(line);
+
+              if (!track.id || !track.title) continue;
+
+              // Accept soundcloud.com URLs; fall back to webpage_url if available
+              const url: string | undefined =
+                (track.webpage_url as string | undefined) || (track.url as string | undefined);
+
+              if (!url || !this.isSoundCloudUrl(url)) continue;
+
+              const creator: string | undefined =
+                (track.uploader as string | undefined) || (track.artist as string | undefined) || undefined;
+              const thumbnail: string | undefined =
+                (track.thumbnail as string | undefined) ||
+                (track.thumbnails?.[0]?.url as string | undefined) ||
+                undefined;
+
+              results.push(
+                this.createMusicSource({
+                  title: this.cleanTitle(track.title as string),
+                  url,
+                  ...(typeof track.duration === 'number' ? { duration: track.duration } : {}),
+                  ...(creator !== undefined ? { creator } : {}),
+                  ...(thumbnail !== undefined ? { thumbnail } : {}),
+                  isLiveStream: false,
+                }),
+              );
+            } catch {
+              // skip malformed JSON lines
+            }
+          }
+
+          logEvent('soundcloud_search_parsed', { query, foundTracks: results.length });
+          resolve(results);
+        } catch (error) {
+          logError('Failed to parse yt-dlp SoundCloud output', error as Error, {
+            query,
+            output: output.substring(0, 500),
+          });
+          resolve([]);
+        }
+      });
+
+      ytDlp.on('error', (error) => {
+        logError('yt-dlp SoundCloud process error', error, { query });
+        resolve([]);
+      });
+    });
+  }
+
+  /**
+   * Validates that a URL belongs to SoundCloud (soundcloud.com).
+   * Overrides BaseMusicService.validateUrl for SoundCloud-specific check.
+   */
+  validateUrl(url: string): boolean {
+    return this.isSoundCloudUrl(url);
+  }
+
+  private isSoundCloudUrl(url: string): boolean {
+    try {
+      const { hostname } = new URL(url);
+      return hostname === 'soundcloud.com' || hostname.endsWith('.soundcloud.com');
+    } catch {
+      return false;
+    }
+  }
+}

--- a/src/types/music.ts
+++ b/src/types/music.ts
@@ -39,7 +39,7 @@ export interface GuildMusicData {
   playedCount?: number;
 }
 
-export type ServiceType = 'youtube' | 'internet_archive' | 'radio' | 'spotify';
+export type ServiceType = 'youtube' | 'internet_archive' | 'radio' | 'spotify' | 'soundcloud';
 
 export type LoopMode = 'off' | 'song' | 'queue';
 
@@ -63,6 +63,7 @@ export interface BotConfig {
     youtube: ServiceConfig;
     internetArchive: ServiceConfig;
     radio: ServiceConfig;
+    soundcloud: ServiceConfig;
   };
   // Optional resolver settings (external YouTube resolver)
   resolver?: {

--- a/src/utils/discord.ts
+++ b/src/utils/discord.ts
@@ -1,21 +1,21 @@
-import { 
-  ChatInputCommandInteraction, 
-  EmbedBuilder, 
+import {
+  ChatInputCommandInteraction,
+  EmbedBuilder,
   ColorResolvable,
   InteractionResponse,
-  Message
+  Message,
 } from 'discord.js';
 import MusaPhrasesJson from '../assets/phrases.json';
 import { ServiceType } from '../types/music';
 
 // Cores da Musa (tons de roxo)
 export const MusaColors = {
-  primary: '#8B5DBC' as ColorResolvable,      // Roxo principal da Musa
-  success: '#9B7FBD' as ColorResolvable,      // Roxo claro para sucesso
-  warning: '#A15BBF' as ColorResolvable,      // Roxo médio para avisos
-  error: '#7A4BB8' as ColorResolvable,        // Roxo escuro para erros
-  queue: '#8E65C4' as ColorResolvable,        // Roxo para queue
-  nowPlaying: '#9F72C7' as ColorResolvable,   // Roxo para "tocando agora"
+  primary: '#8B5DBC' as ColorResolvable, // Roxo principal da Musa
+  success: '#9B7FBD' as ColorResolvable, // Roxo claro para sucesso
+  warning: '#A15BBF' as ColorResolvable, // Roxo médio para avisos
+  error: '#7A4BB8' as ColorResolvable, // Roxo escuro para erros
+  queue: '#8E65C4' as ColorResolvable, // Roxo para queue
+  nowPlaying: '#9F72C7' as ColorResolvable, // Roxo para "tocando agora"
 } as const;
 
 // Emojis musicais da Musa
@@ -67,6 +67,8 @@ export const getServiceEmoji = (service: ServiceType): string => {
       return '📻';
     case 'spotify':
       return '🟢';
+    case 'soundcloud':
+      return '🟠';
     default:
       return '🎵';
   }
@@ -119,13 +121,12 @@ export const createMusaEmbed = (options: {
 export const safeReply = async (
   interaction: ChatInputCommandInteraction,
   content: string | { embeds: EmbedBuilder[] },
-  _ephemeral = true
+  _ephemeral = true,
 ): Promise<InteractionResponse<boolean> | Message<boolean> | null> => {
   try {
     // For policy: always ephemeral. Ignore provided flag.
-    const options = typeof content === 'string' 
-      ? { content, ephemeral: true }
-      : { ...content, ephemeral: true };
+    const options =
+      typeof content === 'string' ? { content, ephemeral: true } : { ...content, ephemeral: true };
 
     if (interaction.replied || interaction.deferred) {
       return await interaction.followUp(options);
@@ -140,15 +141,15 @@ export const safeReply = async (
 
 export const formatDuration = (seconds: number): string => {
   if (!seconds || isNaN(seconds)) return '00:00';
-  
+
   const hours = Math.floor(seconds / 3600);
   const minutes = Math.floor((seconds % 3600) / 60);
   const secs = Math.floor(seconds % 60);
-  
+
   if (hours > 0) {
     return `${hours}:${minutes.toString().padStart(2, '0')}:${secs.toString().padStart(2, '0')}`;
   }
-  
+
   return `${minutes}:${secs.toString().padStart(2, '0')}`;
 };
 
@@ -164,5 +165,5 @@ export const getRandomPhrase = (category: keyof typeof MusaPhrases | string): st
   const phrases = (MusaPhrases as any)[category] as string[] | undefined;
   const list = phrases && phrases.length > 0 ? phrases : [''];
   const randomIndex = Math.floor(Math.random() * list.length);
-  return (list[randomIndex] ?? list[0] ?? '');
+  return list[randomIndex] ?? list[0] ?? '';
 };

--- a/tests/configSchema.test.js
+++ b/tests/configSchema.test.js
@@ -73,8 +73,28 @@ describe('config schema loader', () => {
       expect(cfg.logging.level).toBe('DEBUG');
       expect(cfg.services.youtube.enabled).toBe(false);
       expect(cfg.services.radio.enabled).toBe(true);
+      // SoundCloud defaults to enabled with priority 4
+      expect(cfg.services.soundcloud.enabled).toBe(true);
+      expect(cfg.services.soundcloud.priority).toBe(4);
       expect(cfg.music.maxQueueSize).toBeGreaterThan(0);
     });
+  });
+
+  test('ENABLE_SOUNDCLOUD can be toggled off', () => {
+    const { loadBotConfig } = reloadLoader();
+    withVars(
+      {
+        ...clearSetupEnvExcept(['DISCORD_TOKEN']),
+        DISCORD_TOKEN: 'x',
+        ENABLE_SOUNDCLOUD: 'false',
+        SOUNDCLOUD_PRIORITY: '5',
+      },
+      () => {
+        const cfg = loadBotConfig();
+        expect(cfg.services.soundcloud.enabled).toBe(false);
+        expect(cfg.services.soundcloud.priority).toBe(5);
+      },
+    );
   });
 
   test('boolean coercion and proxy alias', () => {


### PR DESCRIPTION
## O que é

Adiciona o **SoundCloud como fonte de fallback** para quando o YouTube retorna vazio ou falha. Bot deixa de ficar mudo — cai pro SoundCloud automaticamente.

### Por que SoundCloud é o fallback ideal

- Rate-limit **por `client_id`**, não por IP — funciona direto da VM Oracle (datacenter) sem WARP/proxy
- Extractor `scsearch` maduro no yt-dlp — reusa 100% da pipeline de stream existente (yt-dlp pipe)
- Catálogo complementar ao YouTube: forte em remixes, sped-up, DJ sets, lo-fi, releases indie

## Como o fallback foi integrado (MultiSourceManager)

**Waterfall real, não fan-out:**

1. YouTube (primário) é consultado primeiro
2. Se YouTube retornar `results.length === 0` → `soundcloud_fallback_triggered` é logado e o SoundCloud é consultado
3. Se YouTube tiver resultados → SoundCloud **não é chamado** (zero latência extra no caso feliz)
4. Radio/InternetArchive continuam em fan-out paralelo com o primário (comportamento inalterado)

Tiers no código:
- `FALLBACK_SERVICES = ['soundcloud']` — só quando primário vazia
- `PASSTHROUGH_SERVICES = ['radio', 'internet_archive']` — fan-out sempre
- Tudo o mais (youtube, resolver-youtube) = primário

## Mudanças de playback (MusicManager)

`playAudio` roteia `song.service === 'soundcloud'` para o mesmo `createYouTubeStreamResource` (yt-dlp pipe). SoundCloud não precisa de proxy/cookies — o yt-dlp resolve o `client_id` automaticamente.

## Arquivos alterados

| Arquivo | O que mudou |
|---|---|
| `src/services/SoundCloudService.ts` | **Novo.** BaseMusicService com scsearch, sem proxy/cookies/player_client |
| `src/types/music.ts` | ServiceType += 'soundcloud'; BotConfig.services.soundcloud adicionado |
| `src/config/schema.ts` | ENABLE_SOUNDCLOUD (default true) + SOUNDCLOUD_PRIORITY (default 4) |
| `src/services/MultiSourceManager.ts` | Registra SoundCloudService + lógica waterfall no search() |
| `src/services/MusicManager.ts` | playAudio: soundcloud -> mesma branch do YouTube (yt-dlp pipe) |
| `src/utils/discord.ts` | getServiceEmoji('soundcloud') retorna 'orange circle' |
| `.env.template` | Documenta ENABLE_SOUNDCLOUD e SOUNDCLOUD_PRIORITY |
| `tests/configSchema.test.js` | 2 novos testes: defaults soundcloud + toggle-off |

## Config

```env
ENABLE_SOUNDCLOUD=true        # default true — fallback ativo out-of-the-box
SOUNDCLOUD_PRIORITY=4         # priority > YouTube(3), logo vem depois
```

## O que ficou faltando

Nada bloqueante. Note sobre o build:

O workspace tem arquivos de outro PR em progresso (`StatusRenderer.ts`, `statusView.ts`, `statusStore.ts` — branch feat/status-renderer-buttons) que causam erros de tsc no `npm run build` completo. Esses erros são **pre-existentes naqueles arquivos** e não pertencem a este PR. Os arquivos deste PR compilam limpos: `tsc --noEmit` confirmado sem erros. Jest (27/27 testes, incluindo 2 novos) passou contra o dist construido em isolamento.

## Como testar (Vitor pos-deploy)

1. Derrubar o WARP / setar `YTDLP_PROXY=""` temporariamente para forcar YouTube a falhar
2. `/play <termo>` — bot deve cair no SoundCloud e tocar
3. Log `soundcloud_fallback_triggered` deve aparecer nos logs
4. Remover sabotagem -> YouTube volta a ser primario sem reconfiguração

---
Built by VHXCO Builder <ops@vhxco.io>