### PR TITLE
feat: auto-register slash commands on bot startup

### DIFF
--- a/src/deploy-commands.ts
+++ b/src/deploy-commands.ts
@@ -1,69 +1,30 @@
-import { REST, Routes } from 'discord.js';
-import fs from 'fs';
 import path from 'path';
 import { botConfig } from './config';
+import { loadCommandPayloads, registerCommands } from './utils/registerCommands';
 
-const commands = [];
 const commandsPath = path.join(__dirname, 'commands');
+const commands = loadCommandPayloads(commandsPath);
 
-// Determine file extension based on whether we're running compiled JS or TS
-const isCompiled = __filename.endsWith('.js');
-const fileExtension = isCompiled ? '.js' : '.ts';
-
-const commandFiles = fs
-  .readdirSync(commandsPath)
-  .filter((file) => file.endsWith(fileExtension) && file !== 'index' + fileExtension);
-
-for (const file of commandFiles) {
-  const filePath = path.join(commandsPath, file);
-  // eslint-disable-next-line @typescript-eslint/no-var-requires
-  const command = require(filePath);
-  const commandData = command.default || command;
-
-  if ('data' in commandData && 'execute' in commandData) {
-    commands.push(commandData.data.toJSON());
-    console.log(`✅ Loaded command: ${commandData.data.name}`);
-  } else {
-    console.log(`⚠️  Skipped ${file}: Missing required data or execute property`);
-  }
-}
-
-// Construct and prepare an instance of the REST module
-const rest = new REST().setToken(botConfig.token);
-
-// Deploy commands
 (async () => {
   try {
     console.log(`🚀 Started refreshing ${commands.length} application (/) commands.`);
 
-    // Register commands globally (takes up to 1 hour to update)
-    // For development, use guild-specific registration (instant)
+    const result = await registerCommands(botConfig, commands);
 
-    if (botConfig.guildId) {
-      // Development: Register to specific guild (instant)
-      const data = (await rest.put(Routes.applicationGuildCommands(botConfig.clientId, botConfig.guildId), {
-        body: commands,
-      })) as any[];
-
-      console.log(
-        `✅ Successfully reloaded ${data.length} guild (/) commands for guild ${botConfig.guildId}.`,
-      );
+    if (result.mode === 'guild') {
+      console.log(`✅ Successfully reloaded ${result.count} guild (/) commands for guild ${result.guildId}.`);
       console.log(`⚡ Guild commands appear immediately in Discord.`);
     } else {
-      // Production: Register globally
-      const data = (await rest.put(Routes.applicationCommands(botConfig.clientId), {
-        body: commands,
-      })) as any[];
-
-      console.log(`✅ Successfully reloaded ${data.length} global (/) commands.`);
+      console.log(`✅ Successfully reloaded ${result.count} global (/) commands.`);
       console.log('⏰ Global commands may take up to 1 hour to appear in Discord.');
     }
 
     console.log('\n📋 Registered commands:');
-    commands.forEach((cmd: any) => {
+    (commands as any[]).forEach((cmd) => {
       console.log(`  - /${cmd.name}: ${cmd.description}`);
     });
   } catch (error) {
     console.error('❌ Error registering commands:', error);
+    process.exit(1);
   }
 })();

--- a/src/events/ready.ts
+++ b/src/events/ready.ts
@@ -1,24 +1,53 @@
 import { Client, Events } from 'discord.js';
+import path from 'path';
 import { logEvent } from '../utils/logger';
 import { getRandomPhrase } from '../utils/discord';
 import { PresenceManager } from '../services/PresenceManager';
+import { loadCommandPayloads, registerCommands } from '../utils/registerCommands';
+import { botConfig } from '../config';
 
 export default {
   name: Events.ClientReady,
   once: true,
-  execute(client: Client<true>) {
+  async execute(client: Client<true>) {
     const readyMessage = getRandomPhrase('ready');
-    
+
     console.log(`🎵 ${readyMessage}`);
     console.log(`🧚‍♀️ Conectada como ${client.user.tag}`);
-    console.log(`🎭 Ativa em ${client.guilds.cache.size} servidor${client.guilds.cache.size !== 1 ? 'es' : ''}`);
-    
+    console.log(
+      `🎭 Ativa em ${client.guilds.cache.size} servidor${client.guilds.cache.size !== 1 ? 'es' : ''}`,
+    );
+
     logEvent('bot_ready', {
       botTag: client.user.tag,
       botId: client.user.id,
       guildCount: client.guilds.cache.size,
-      userCount: client.guilds.cache.reduce((acc, guild) => acc + guild.memberCount, 0)
+      userCount: client.guilds.cache.reduce((acc, guild) => acc + guild.memberCount, 0),
     });
+
+    // Auto-register slash commands on every boot.
+    // Guild mode is instantaneous; global mode has ~1h propagation.
+    // Failure is non-fatal: the bot keeps running with the previously registered commands.
+    try {
+      const commandsPath = path.join(__dirname, '..', 'commands');
+      const payloads = loadCommandPayloads(commandsPath);
+      const result = await registerCommands(botConfig, payloads);
+
+      const modeLabel = result.mode === 'guild' ? `guild ${result.guildId}` : 'global';
+
+      console.log(`✅ ${result.count} comandos registrados (${modeLabel})`);
+      logEvent('commands_registered', {
+        count: result.count,
+        mode: result.mode,
+        ...(result.guildId ? { guildId: result.guildId } : {}),
+      });
+    } catch (error) {
+      // Non-fatal: log and continue. The bot still works with its last registered commands.
+      console.error('⚠️  Falha ao registrar comandos no boot (nao critico):', error);
+      logEvent('commands_register_failed', {
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
 
     // Iniciar presença ociosa rotativa (frases de silêncio) até que uma faixa comece
     try {

--- a/src/utils/registerCommands.ts
+++ b/src/utils/registerCommands.ts
@@ -1,0 +1,74 @@
+import { REST, Routes } from 'discord.js';
+import fs from 'fs';
+import path from 'path';
+import { BotConfig } from '../types/music';
+import { logger } from './logger';
+
+/**
+ * Loads all slash command JSON payloads from the commands directory.
+ * Resolves both compiled (.js) and source (.ts) environments automatically.
+ */
+export function loadCommandPayloads(commandsDir: string): object[] {
+  const isCompiled = __filename.endsWith('.js');
+  const fileExtension = isCompiled ? '.js' : '.ts';
+  const indexFile = 'index' + fileExtension;
+
+  const commandFiles = fs
+    .readdirSync(commandsDir)
+    .filter((file) => file.endsWith(fileExtension) && file !== indexFile);
+
+  const payloads: object[] = [];
+
+  for (const file of commandFiles) {
+    const filePath = path.join(commandsDir, file);
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    const command = require(filePath);
+    const commandData = command.default || command;
+
+    if ('data' in commandData && 'execute' in commandData) {
+      payloads.push(commandData.data.toJSON());
+    } else {
+      logger.warn('⚠️  registerCommands_skip', {
+        file,
+        reason: 'Missing required data or execute property',
+      });
+    }
+  }
+
+  return payloads;
+}
+
+export interface RegisterCommandsResult {
+  count: number;
+  mode: 'guild' | 'global';
+  guildId?: string;
+}
+
+/**
+ * Registers slash commands with the Discord API.
+ *
+ * - Guild mode  (instantaneous): when `config.guildId` is set.
+ * - Global mode (up to 1 h lag): fallback when no guildId.
+ *
+ * Throws on API/network errors — callers decide whether to swallow or rethrow.
+ */
+export async function registerCommands(
+  config: Pick<BotConfig, 'token' | 'clientId' | 'guildId'>,
+  commandPayloads: object[],
+): Promise<RegisterCommandsResult> {
+  const rest = new REST().setToken(config.token);
+
+  if (config.guildId) {
+    const data = (await rest.put(Routes.applicationGuildCommands(config.clientId, config.guildId), {
+      body: commandPayloads,
+    })) as object[];
+
+    return { count: data.length, mode: 'guild', guildId: config.guildId };
+  }
+
+  const data = (await rest.put(Routes.applicationCommands(config.clientId), {
+    body: commandPayloads,
+  })) as object[];
+
+  return { count: data.length, mode: 'global' };
+}


### PR DESCRIPTION
## O footgun

O bot registrava comandos **apenas na memória local** (`client.commands.set`) durante o startup. O registro real na API do Discord ficava no script separado `src/deploy-commands.ts`, que precisava ser rodado **manualmente** via `npm run deploy` toda vez que uma definição de comando mudava.

Resultado: quando o `/radio` ganhou novas opções no PR #19, o Discord continuou servindo a definição antiga até o deploy manual ser feito — causando erros "Required option not found" em produção hoje.

## O fix

### 1. Módulo compartilhado `src/utils/registerCommands.ts`
- `loadCommandPayloads(commandsDir)` — carrega os JSON payloads de todos os comandos (detecta `.js` vs `.ts` automaticamente)
- `registerCommands(config, payloads)` — faz o `rest.put` via Discord API
  - **Guild mode** (instantâneo) quando `GUILD_ID` está setado
  - **Global mode** (~1h propagação) como fallback
  - Retorna `{ count, mode, guildId? }` para log estruturado

### 2. Auto-registro no evento `ready` (`src/events/ready.ts`)
- Chamada única no boot, logo após o cliente estar pronto
- Envolta em `try/catch`: **falha de rede/rate-limit loga o erro mas NÃO derruba o bot** — ele continua operando com os comandos já registrados no Discord
- Log estruturado via `logEvent('commands_registered', { count, mode, guildId? })`

### 3. `deploy-commands.ts` refatorado (DRY)
- Agora usa `loadCommandPayloads` + `registerCommands` do módulo compartilhado
- Mantém funcionalidade idêntica para uso manual/CI (`npm run deploy`)

## Validação
- `npm run build` — verde
- `npm run typecheck` — verde
- `npm run lint` — 0 errors (warnings pré-existentes no repo)
- `npm test` — 40/40 passed

---
Built by VHXCO Builder <ops@vhxco.io>