### PR TITLE
feat(play): source option (Auto/YouTube/SoundCloud) + SoundCloud URL passthrough

### DIFF
--- a/src/commands/play.ts
+++ b/src/commands/play.ts
@@ -13,7 +13,8 @@ import {
 } from '../utils/discord';
 import { logEvent, logError } from '../utils/logger';
 import { botConfig } from '../config';
-import { analyzeUrl, detectProvider, detectContentKind } from '../utils/providers';
+import { analyzeUrl, detectProvider, detectContentKind, isSoundCloudUrl } from '../utils/providers';
+import { ServiceType } from '../types/music';
 import { SpotifyPlaylistProvider } from '../services/providers/SpotifyPlaylistProvider';
 import { TrackResolver } from '../services/TrackResolver';
 import { spawn } from 'child_process';
@@ -26,9 +27,20 @@ export default {
     .addStringOption((option) =>
       option
         .setName('query')
-        .setDescription('Nome da música, artista ou termo de busca')
+        .setDescription('Nome da música, artista ou URL (YouTube, Spotify, SoundCloud)')
         .setRequired(true)
         .setMaxLength(200),
+    )
+    .addStringOption((option) =>
+      option
+        .setName('source')
+        .setDescription('☁️ Fonte de busca (padrão: Auto — YouTube → SoundCloud fallback)')
+        .setRequired(false)
+        .addChoices(
+          { name: '🔀 Auto (YouTube → SoundCloud fallback)', value: 'auto' },
+          { name: '▶️ YouTube', value: 'youtube' },
+          { name: '☁️ SoundCloud', value: 'soundcloud' },
+        ),
     ),
 
   async execute(interaction: ChatInputCommandInteraction, musicManager: MusicManager): Promise<void> {
@@ -36,6 +48,11 @@ export default {
       await interaction.deferReply({ ephemeral: true });
 
       const query = interaction.options.getString('query', true);
+      // 'auto' = default waterfall (YouTube primary → SoundCloud fallback).
+      // 'youtube' or 'soundcloud' forces that single source, bypassing the waterfall.
+      const sourceOption = interaction.options.getString('source') ?? 'auto';
+      const forceSource: ServiceType | undefined =
+        sourceOption === 'auto' ? undefined : (sourceOption as ServiceType);
       const member = interaction.member as GuildMember;
       const guildId = interaction.guildId!;
 
@@ -50,6 +67,7 @@ export default {
         guildId,
         userId: member.id,
         query,
+        source: sourceOption,
         voiceChannel: validationResult.voiceChannel!.name,
       });
 
@@ -68,6 +86,13 @@ export default {
         if (!selectedSong) {
           // fallback mínimo
           selectedSong = { title: watchUrl, url: watchUrl, service: 'youtube' };
+        }
+      } else if (provider === 'soundcloud' || isSoundCloudUrl(query)) {
+        // URL direta do SoundCloud — resolve metadados e toca via SoundCloud (yt-dlp pipe)
+        selectedSong = await this.fetchSoundCloudMeta(query);
+        if (!selectedSong) {
+          // fallback mínimo: a URL em si é suficiente para o yt-dlp pipe
+          selectedSong = { title: query, url: query, service: 'soundcloud' };
         }
       } else if (provider === 'spotify' && kind === 'track') {
         // Pegar metadados do Spotify e resolver para YouTube
@@ -98,13 +123,14 @@ export default {
           thumbnail: meta.thumbnailUrl || undefined,
         };
       } else {
-        // Buscar música via MultiSource
-        selectedSong = await this.searchMusic(query, musicManager);
+        // Buscar música via MultiSource, com fonte forçada se especificada
+        selectedSong = await this.searchMusic(query, musicManager, forceSource);
       }
       if (!selectedSong) {
+        const sourceLabel = forceSource ? ` no ${forceSource}` : '';
         const embed = createMusaEmbed({
           title: 'Nenhuma Música Encontrada',
-          description: `${MusaEmojis.search} Não consegui encontrar "${truncateText(query, 50)}" em nenhuma das minhas fontes musicais! Tente um termo diferente! ${MusaEmojis.notes}`,
+          description: `${MusaEmojis.search} Não consegui encontrar "${truncateText(query, 50)}"${sourceLabel}! Tente um termo diferente! ${MusaEmojis.notes}`,
           color: MusaColors.warning,
         });
 
@@ -181,10 +207,10 @@ export default {
     return { success: true, voiceChannel: userVoiceChannel };
   },
 
-  async searchMusic(query: string, musicManager: MusicManager) {
+  async searchMusic(query: string, musicManager: MusicManager, forceSource?: ServiceType) {
     const searchResults = await musicManager
       .getMultiSourceManager()
-      .search(query, botConfig.services.youtube.maxResults);
+      .search(query, botConfig.services.youtube.maxResults, forceSource);
 
     return searchResults.length > 0 ? searchResults[0] : null;
   },
@@ -375,6 +401,56 @@ export default {
         }
       });
       p.on('error', () => resolve({ title: videoUrl, url: videoUrl, service: 'youtube' }));
+    });
+  },
+
+  /**
+   * Resolve metadata for a direct SoundCloud URL via yt-dlp --dump-json.
+   * No proxy needed — SoundCloud is accessible from datacenter IPs.
+   * Returns a MusicSource-compatible object with service: 'soundcloud'.
+   *
+   * ☁️ SoundCloud tracks play via the same yt-dlp pipe path as YouTube
+   * (MusicManager.createYouTubeStreamResource routes on service === 'soundcloud').
+   */
+  async fetchSoundCloudMeta(trackUrl: string): Promise<any | null> {
+    return new Promise((resolve) => {
+      let output = '';
+      logEvent('soundcloud_url_meta_fetch', { url: trackUrl });
+
+      // Minimal args: no proxy, no cookies — SoundCloud doesn't need them.
+      const args = [
+        '--dump-json',
+        '--no-warnings',
+        '--skip-download',
+        '--user-agent',
+        'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/118.0.0.0 Safari/537.36',
+        trackUrl,
+      ];
+      const p = spawn('yt-dlp', args);
+      p.stdout.on('data', (d: Buffer) => {
+        output += d.toString();
+      });
+      p.on('close', () => {
+        try {
+          const data = JSON.parse(output.trim().split('\n')[0] || '{}');
+          if (!data || !data.title) {
+            logEvent('soundcloud_url_meta_fallback', { url: trackUrl });
+            return resolve({ title: trackUrl, url: trackUrl, service: 'soundcloud' });
+          }
+          return resolve({
+            title: data.title as string,
+            url: (data.webpage_url as string) || trackUrl,
+            duration: typeof data.duration === 'number' ? data.duration : undefined,
+            creator: (data.uploader as string) || (data.artist as string) || undefined,
+            thumbnail: (data.thumbnail as string) || undefined,
+            service: 'soundcloud',
+          });
+        } catch {
+          logEvent('soundcloud_url_meta_parse_error', { url: trackUrl });
+          return resolve({ title: trackUrl, url: trackUrl, service: 'soundcloud' });
+        }
+      });
+      p.on('error', () => resolve({ title: trackUrl, url: trackUrl, service: 'soundcloud' }));
     });
   },
 };

--- a/src/services/MultiSourceManager.ts
+++ b/src/services/MultiSourceManager.ts
@@ -76,7 +76,11 @@ export class MultiSourceManager {
     }
   }
 
-  async search(query: string, maxResultsPerService?: number): Promise<MusicSource[]> {
+  async search(
+    query: string,
+    maxResultsPerService?: number,
+    forceSource?: ServiceType,
+  ): Promise<MusicSource[]> {
     if (this.enabledServices.length === 0) {
       logWarning('No enabled services available for search', { query });
       return [];
@@ -85,8 +89,29 @@ export class MultiSourceManager {
     logEvent('multi_source_search_started', {
       query,
       maxResultsPerService,
+      forceSource: forceSource ?? 'auto',
       enabledServices: this.enabledServices.length,
     });
+
+    // --- Forced source path: bypass primary/fallback/passthrough tiers entirely ---
+    if (forceSource) {
+      const forcedService = this.enabledServices.find((s) => s.getServiceName() === forceSource);
+      if (!forcedService) {
+        logWarning('Forced source service not enabled or not found', { query, forceSource });
+        return [];
+      }
+      try {
+        const results = await forcedService.search(query, maxResultsPerService);
+        logEvent('force_source_search_completed', { query, forceSource, resultsCount: results.length });
+        return results.filter((r) => {
+          if (r.service !== 'youtube') return true;
+          return typeof r.url === 'string' && isYouTubeVideoUrl(r.url);
+        });
+      } catch (error) {
+        logError(`Forced source search failed: ${forceSource}`, error as Error, { query, forceSource });
+        return [];
+      }
+    }
 
     // Tier separation for waterfall fallback:
     //  - FALLBACK_SERVICES: only queried when all primary music sources return empty

--- a/src/utils/providers.ts
+++ b/src/utils/providers.ts
@@ -1,4 +1,4 @@
-export type Provider = 'youtube' | 'ytm' | 'spotify' | 'unknown';
+export type Provider = 'youtube' | 'ytm' | 'spotify' | 'soundcloud' | 'unknown';
 export type ContentKind = 'track' | 'playlist' | 'unknown';
 
 export interface DetectedUrlInfo {
@@ -19,6 +19,8 @@ const YTM_HOSTS = new Set(['music.youtube.com', 'www.music.youtube.com']);
 
 const SPOTIFY_HOSTS = new Set(['open.spotify.com']);
 
+const SC_HOSTS = new Set(['soundcloud.com', 'www.soundcloud.com', 'on.soundcloud.com', 'm.soundcloud.com']);
+
 function safeParseUrl(input: string): URL | null {
   try {
     // If input is missing protocol, try to prepend https://
@@ -33,6 +35,13 @@ function safeParseUrl(input: string): URL | null {
 
 function getHost(url: URL): string {
   return url.hostname.toLowerCase();
+}
+
+/** Returns true when the input is a direct soundcloud.com URL */
+export function isSoundCloudUrl(input: string): boolean {
+  const u = safeParseUrl(input);
+  if (!u) return false;
+  return SC_HOSTS.has(getHost(u));
 }
 
 export function isYouTubeVideoUrl(input: string): boolean {
@@ -75,6 +84,7 @@ export function detectProvider(input: string): Provider {
   if (YTM_HOSTS.has(h)) return 'ytm';
   if (YT_HOSTS.has(h)) return 'youtube';
   if (SPOTIFY_HOSTS.has(h)) return 'spotify';
+  if (SC_HOSTS.has(h)) return 'soundcloud';
   return 'unknown';
 }
 


### PR DESCRIPTION
## Summary

- Adiciona opção `source` ao `/play` com choices: **Auto** (padrão), **YouTube**, **SoundCloud**
- **Auto** = comportamento existente (YouTube primário → SoundCloud fallback automático)
- **YouTube** = força só YouTube, ignora waterfall
- **SoundCloud** = força só SoundCloud — é o que o Vitor precisa pra testar o SC
- URLs `soundcloud.com/...` passadas no `query` são detectadas automaticamente e tocam via SoundCloud
- `MultiSourceManager.search()` recebe `forceSource?: ServiceType` opcional

## Como testar SoundCloud

1. `/play source:SoundCloud query:nome da música` — força busca no SoundCloud
2. `/play query:https://soundcloud.com/artista/track` — URL direta detectada automaticamente
3. `/play query:nome` (sem source) — Auto inalterado: YouTube primário → SC fallback se YT vazio

## Arquivos alterados

- `src/utils/providers.ts` — `soundcloud` no tipo `Provider`, `SC_HOSTS`, `isSoundCloudUrl()`, `detectProvider()` detecta soundcloud.com
- `src/services/MultiSourceManager.ts` — `search()` aceita `forceSource?: ServiceType`; quando definido, bypassa tiers e consulta só o serviço pedido
- `src/commands/play.ts` — nova opção `source` no SlashCommand, branch para URL SC (`fetchSoundCloudMeta`), propagação do `forceSource` para busca

## Nota sobre re-registro

A adição da opção `source` muda a definição do slash command `/play`. O PR de auto-register (`feat/auto-register-commands`) resolve isso no boot — no deploy conjunto o re-registro é automático.

## Test plan

- [x] Build TypeScript: verde
- [x] Test suite: 40/40 passando
- [ ] Smoke real pós-deploy: `/play query:lofi hip hop source:SoundCloud`
- [ ] Smoke URL: `/play query:https://soundcloud.com/nocopyrightsounds/ncs-fade`
- [ ] Auto path inalterado: `/play query:lofi hip hop` (sem source)

---
🏗 Built by VHXCO Agentic Software House